### PR TITLE
feat: add base class

### DIFF
--- a/src/geotech_pandas/base.py
+++ b/src/geotech_pandas/base.py
@@ -1,0 +1,10 @@
+"""A module containing a common class used throughout the geotech-pandas package."""
+
+import pandas as pd
+
+
+class GeotechPandasBase:
+    """A base class with common validation methods for dataframes."""
+
+    def __init__(self, df: pd.DataFrame) -> None:
+        self._obj = df

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,19 @@
+"""Test base class methods."""
+
+import pandas as pd
+import pandas._testing as tm
+
+from geotech_pandas.base import GeotechPandasBase
+
+base_df = pd.DataFrame(
+    {
+        "PointID": ["BH-1", "BH-1", "BH-2", "BH-2"],
+        "Bottom": [0.0, 1.0, 0.0, 1.0],
+    }
+)
+
+
+def test_obj():
+    """Test if dataframe is stored in ``_obj``."""
+    gpdf = GeotechPandasBase(base_df)
+    tm.assert_frame_equal(base_df, gpdf._obj)


### PR DESCRIPTION
## Description
The GeotechPandasBase class is a placeholder for common methods used throughout the geotech-pandas package. For now, it only has the basic function of storing the supplied dataframe to the class's ``_obj`` property. Common methods, such as validation of the dataframe before manipulation, should be placed here in the future.

## Tasks
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.