### PR TITLE
feat: call validators in base class `__init__`

### DIFF
--- a/src/geotech_pandas/base.py
+++ b/src/geotech_pandas/base.py
@@ -7,6 +7,9 @@ class GeotechPandasBase:
     """A base class with common validation methods for dataframes."""
 
     def __init__(self, df: pd.DataFrame) -> None:
+        self.validate_columns(df)
+        self.validate_monotony(df)
+        self.validate_duplicates(df)
         self._obj = df
 
     @staticmethod

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -120,3 +120,45 @@ def test_validate_duplicates(df, error, error_message):
     with error as e:
         GeotechPandasBase.validate_duplicates(df)
         assert error_message is None or error_message in str(e)
+
+
+@pytest.mark.parametrize(
+    ("df", "error", "error_message"),
+    [
+        (
+            base_df[["PointID"]].copy(),
+            pytest.raises(AttributeError),
+            "The dataframe must have: Bottom column.",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "PointID": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
+                    "Bottom": [0.0, 2.0, 1.0, 0.0, 1.0],
+                }
+            ),
+            pytest.raises(AttributeError),
+            "Elements in the Bottom column must be monotonically increasing for: BH-1.",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "PointID": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
+                    "Bottom": [0.0, 1.0, 1.0, 0.0, 1.0],
+                }
+            ),
+            pytest.raises(AttributeError),
+            "The dataframe contains duplicate PointID and Bottom: BH-1.",
+        ),
+        (
+            base_df,
+            does_not_raise(),
+            None,
+        ),
+    ],
+)
+def test_validatorsj(df, error, error_message):
+    """Test if validators are triggered for wrong dataframe configurations."""
+    with error as e:
+        GeotechPandasBase(df)
+        assert error_message is None or error_message in str(e)


### PR DESCRIPTION
## Description
The validator methods are called first in the `__init__` method of the base class before storing the dataframe in `_obj` so that the validators do not need to be called manually when using the base class.

## Tasks
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.