### PR TITLE
feat: add point `DataFrame` accessor

### DIFF
--- a/src/geotech_pandas/point.py
+++ b/src/geotech_pandas/point.py
@@ -1,0 +1,29 @@
+"""A module containing a custom accessor for pandas that adds methods for depth related points."""
+
+from pandas.core.groupby.generic import DataFrameGroupBy
+
+from geotech_pandas.base import GeotechPandasBase
+
+
+class PointDataFrameAccessor(GeotechPandasBase):
+    """
+    An accessor class that contains methods for depth-related points.
+
+    The dataframe should have ``PointID`` and ``Bottom`` columns, where ``PointID`` would signify
+    what group the ``Bottom`` depths and other related data belong to. These groups can be accessed
+    as a `DataFrameGroupBy` object through the `groups` property.
+    """
+
+    @property
+    def groups(self) -> DataFrameGroupBy:
+        """
+        Return a pandas `DataFrameGroupBy` object based on the ``PointID`` column.
+
+        This can be used a shortcut for grouping the dataframe by the ``PointID``.
+
+        Returns
+        -------
+        DataFrameGroupBy
+            GroupBy object that contains the grouped dataframes.
+        """
+        return self._obj.groupby("PointID")

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from geotech_pandas.point import PointDataFrameAccessor
+
+base_df = pd.DataFrame(
+    {
+        "PointID": ["BH-1", "BH-1", "BH-2", "BH-2"],
+        "Bottom": [0.0, 1.0, 0.0, 1.0],
+    }
+)
+
+
+def test_groups():
+    """Test if groups property returns a `DataFrameGroupBy` object."""
+    df = PointDataFrameAccessor(base_df)
+    g = df.groups
+    assert len(base_df["PointID"].unique()) == len(g)


### PR DESCRIPTION
## Description
The `PointDataFrameAccessor` adds methods for handling depth-related data, such as soil layers. The only requirements for having depth-related data are to have the ``PointID`` and ``Bottom`` columns in the `DataFrame`. Where the ``PointID`` signifies the group where the ``Bottom`` depth and other related data belong to.

The `groups` property is also added in this commit, which returns the `GroupBy` object that contains the `DataFrame` grouped by the `PointID`. This can be used as a shortcut for grouping the `DataFrame` by the `PointID`.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.