### PR TITLE
feat: add ability to get group from point groups

### DIFF
--- a/src/geotech_pandas/point.py
+++ b/src/geotech_pandas/point.py
@@ -27,3 +27,19 @@ class PointDataFrameAccessor(GeotechPandasBase):
             GroupBy object that contains the grouped dataframes.
         """
         return self._obj.groupby("PointID")
+
+    def get_group(self, point_id: str):
+        """
+        Return a `DataFrame` from the point groups with provided `PointID`.
+
+        Parameters
+        ----------
+        point_id: str
+            PointID of the group to get as a DataFrame.
+
+        Returns
+        -------
+        DataFrame
+            DataFrame that matches `point_id`.
+        """
+        return self.groups.get_group(point_id)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pandas._testing as tm
 
 from geotech_pandas.point import PointDataFrameAccessor
 
@@ -15,3 +16,10 @@ def test_groups():
     df = PointDataFrameAccessor(base_df)
     g = df.groups
     assert len(base_df["PointID"].unique()) == len(g)
+
+
+def test_get_group():
+    """Test if `get_group` returns the correct `DataFrame` object."""
+    df = PointDataFrameAccessor(base_df)
+    for point_id in base_df["PointID"].to_list():
+        tm.assert_frame_equal(base_df[base_df["PointID"] == point_id], df.get_group(point_id))


### PR DESCRIPTION
## Description
Add a `get_group` method to `PointDataFrameAccessor` that can be used to get a specified `PointID` from the point groups as a `DataFrame`.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.