### PR TITLE
feat: add ability to get top depth values

### DIFF
--- a/src/geotech_pandas/point.py
+++ b/src/geotech_pandas/point.py
@@ -1,5 +1,6 @@
 """A module containing a custom accessor for pandas that adds methods for depth related points."""
 
+import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy
 
 from geotech_pandas.base import GeotechPandasBase
@@ -43,3 +44,19 @@ class PointDataFrameAccessor(GeotechPandasBase):
             DataFrame that matches `point_id`.
         """
         return self.groups.get_group(point_id)
+
+    def get_top(self, fill_value: float = 0.0) -> pd.Series:
+        """Return shifted ``Bottom`` depth values that can be used as ``Top`` depth values.
+
+        Parameters
+        ----------
+        fill_value: float, optional
+            Float value to use for newly introduced missing values.
+
+        Returns
+        -------
+        Series
+            Series with shifted ``Bottom`` values.
+        """
+        top = pd.Series(self.groups["Bottom"].shift(1, fill_value=fill_value), name="Top")
+        return top

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -23,3 +23,16 @@ def test_get_group():
     df = PointDataFrameAccessor(base_df)
     for point_id in base_df["PointID"].to_list():
         tm.assert_frame_equal(base_df[base_df["PointID"] == point_id], df.get_group(point_id))
+
+
+def test_get_top():
+    """Test if `get_top` returns correct shifted ``Bottom`` depths."""
+    df = PointDataFrameAccessor(
+        pd.DataFrame(
+            {
+                "PointID": ["BH-1", "BH-1", "BH-2", "BH-2"],
+                "Bottom": [1.0, 2.0, 3.0, 4.0],
+            }
+        )
+    )
+    tm.assert_series_equal(df.get_top(), pd.Series([0.0, 1.0, 0.0, 3.0], name="Top"))


### PR DESCRIPTION
## Description
Add a `get_top` method to `PointDataFrameAccessor` that can be used to get shifted ``Bottom`` depth values as ``Top`` depth values.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.