### PR TITLE
refactor: rename column names to use snake case

### DIFF
--- a/src/geotech_pandas/base.py
+++ b/src/geotech_pandas/base.py
@@ -19,8 +19,8 @@ class GeotechPandasBase:
 
         The `validate_columns` method is a static method that is used to validate the columns of a
         given dataframe. The method takes in a dataframe and a list of columns to be validated. If
-        the validation list is not provided, the method defaults to checking if the ``PointID`` and
-        ``Bottom`` columns are present in the dataframe. If any of the columns in the validation
+        the validation list is not provided, the method defaults to checking if the ``point_id`` and
+        ``bottom`` columns are present in the dataframe. If any of the columns in the validation
         list are not found in the dataframe, the method raises an `AttributeError` and lists the
         missing columns in the error message.
 
@@ -28,7 +28,7 @@ class GeotechPandasBase:
         ----------
         df : pandas.DataFrame
             Dataframe to be validated.
-        columns : list of str, optional, default ["PointID", "Bottom"]
+        columns : list of str, optional, default ["point_id", "bottom"]
             List of column names to be validated.
 
         Raises
@@ -37,7 +37,7 @@ class GeotechPandasBase:
             When any of the columns in the validation list are not found in the dataframe.
         """
         if columns is None:
-            columns = ["PointID", "Bottom"]
+            columns = ["point_id", "bottom"]
 
         missing_columns = []
         for column in columns:
@@ -53,7 +53,7 @@ class GeotechPandasBase:
     @staticmethod
     def validate_monotony(df: pd.DataFrame) -> None:
         """
-        Validate if the ``Bottom`` of each ``PointID`` group is monotonically increasing.
+        Validate if the ``bottom`` of each ``point_id`` group is monotonically increasing.
 
         Parameters
         ----------
@@ -63,21 +63,21 @@ class GeotechPandasBase:
         Raises
         ------
         AttributeError
-            When ``Bottom`` is not monotonically increasing in one or more ``PointID``.
+            When ``bottom`` is not monotonically increasing in one or more ``point_id``.
         """
-        g = df.groupby("PointID")
-        check_df = pd.Series(g["Bottom"].is_monotonic_increasing).to_frame().reset_index()
-        check_list = check_df[~check_df["Bottom"]]["PointID"].to_list()
-        if ~check_df["Bottom"].all():
+        g = df.groupby("point_id")
+        check_df = pd.Series(g["bottom"].is_monotonic_increasing).to_frame().reset_index()
+        check_list = check_df[~check_df["bottom"]]["point_id"].to_list()
+        if ~check_df["bottom"].all():
             raise AttributeError(
-                f"Elements in the Bottom column must be monotonically increasing for:"
+                f"Elements in the bottom column must be monotonically increasing for:"
                 f" {', '.join(check_list)}."
             )
 
     @staticmethod
     def validate_duplicates(df: pd.DataFrame) -> None:
         """
-        Validate the dataframe for duplicate value pairs in the ``PointID`` and ``Bottom`` columns.
+        Validate the dataframe for duplicate value pairs in the ``point_id`` and ``bottom`` columns.
 
         Parameters
         ----------
@@ -87,11 +87,11 @@ class GeotechPandasBase:
         Raises
         ------
         AttributeError
-            When duplicate value pairs in the ``PointID`` and ``Bottom`` columns are detected.
+            When duplicate value pairs in the ``point_id`` and ``bottom`` columns are detected.
         """
-        duplicate_list = df[df[["PointID", "Bottom"]].duplicated()]["PointID"].to_list()
+        duplicate_list = df[df[["point_id", "bottom"]].duplicated()]["point_id"].to_list()
         if len(duplicate_list) > 0:
             raise AttributeError(
-                "The dataframe contains duplicate PointID and Bottom:"
+                "The dataframe contains duplicate point_id and bottom:"
                 f" {', '.join(duplicate_list)}."
             )

--- a/src/geotech_pandas/point.py
+++ b/src/geotech_pandas/point.py
@@ -10,33 +10,33 @@ class PointDataFrameAccessor(GeotechPandasBase):
     """
     An accessor class that contains methods for depth-related points.
 
-    The dataframe should have ``PointID`` and ``Bottom`` columns, where ``PointID`` would signify
-    what group the ``Bottom`` depths and other related data belong to. These groups can be accessed
+    The dataframe should have ``point_id`` and ``bottom`` columns, where ``point_id`` would signify
+    what group the ``bottom`` depths and other related data belong to. These groups can be accessed
     as a `DataFrameGroupBy` object through the `groups` property.
     """
 
     @property
     def groups(self) -> DataFrameGroupBy:
         """
-        Return a pandas `DataFrameGroupBy` object based on the ``PointID`` column.
+        Return a pandas `DataFrameGroupBy` object based on the ``point_id`` column.
 
-        This can be used a shortcut for grouping the dataframe by the ``PointID``.
+        This can be used a shortcut for grouping the dataframe by the ``point_id``.
 
         Returns
         -------
         DataFrameGroupBy
             GroupBy object that contains the grouped dataframes.
         """
-        return self._obj.groupby("PointID")
+        return self._obj.groupby("point_id")
 
     def get_group(self, point_id: str):
         """
-        Return a `DataFrame` from the point groups with provided `PointID`.
+        Return a `DataFrame` from the point groups with provided `point_id`.
 
         Parameters
         ----------
         point_id: str
-            PointID of the group to get as a DataFrame.
+            point_id of the group to get as a DataFrame.
 
         Returns
         -------
@@ -46,7 +46,7 @@ class PointDataFrameAccessor(GeotechPandasBase):
         return self.groups.get_group(point_id)
 
     def get_top(self, fill_value: float = 0.0) -> pd.Series:
-        """Return shifted ``Bottom`` depth values that can be used as ``Top`` depth values.
+        """Return shifted ``bottom`` depth values that can be used as ``top`` depth values.
 
         Parameters
         ----------
@@ -56,7 +56,7 @@ class PointDataFrameAccessor(GeotechPandasBase):
         Returns
         -------
         Series
-            Series with shifted ``Bottom`` values.
+            Series with shifted ``bottom`` values.
         """
-        top = pd.Series(self.groups["Bottom"].shift(1, fill_value=fill_value), name="Top")
+        top = pd.Series(self.groups["bottom"].shift(1, fill_value=fill_value), name="top")
         return top

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,8 +10,8 @@ from geotech_pandas.base import GeotechPandasBase
 
 base_df = pd.DataFrame(
     {
-        "PointID": ["BH-1", "BH-1", "BH-2", "BH-2"],
-        "Bottom": [0.0, 1.0, 0.0, 1.0],
+        "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+        "bottom": [0.0, 1.0, 0.0, 1.0],
     }
 )
 
@@ -26,22 +26,22 @@ def test_obj():
     ("df", "columns", "error", "error_message"),
     [
         (
-            base_df[["PointID"]].copy(),
+            base_df[["point_id"]].copy(),
             None,
             pytest.raises(AttributeError),
-            "The dataframe must have: Bottom column.",
+            "The dataframe must have: bottom column.",
         ),
         (
-            base_df[["PointID"]].copy(),
-            ["PointID", "Top", "Bottom"],
+            base_df[["point_id"]].copy(),
+            ["point_id", "top", "bottom"],
             pytest.raises(AttributeError),
-            "The dataframe must have: Top, Bottom columns.",
+            "The dataframe must have: top, bottom columns.",
         ),
         (
             base_df,
-            ["PointID", "Top", "Bottom"],
+            ["point_id", "top", "bottom"],
             pytest.raises(AttributeError),
-            "The dataframe must have: Top column.",
+            "The dataframe must have: top column.",
         ),
         (
             base_df,
@@ -64,18 +64,18 @@ def test_validate_columns(df, columns, error, error_message):
         (
             pd.DataFrame(
                 {
-                    "PointID": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
-                    "Bottom": [0.0, 2.0, 1.0, 0.0, 1.0],
+                    "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
+                    "bottom": [0.0, 2.0, 1.0, 0.0, 1.0],
                 }
             ),
             pytest.raises(AttributeError),
-            "Elements in the Bottom column must be monotonically increasing for: BH-1.",
+            "Elements in the bottom column must be monotonically increasing for: BH-1.",
         ),
         (
             pd.DataFrame(
                 {
-                    "PointID": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
-                    "Bottom": [0.0, 1.0, 2.0, 0.0, 1.0],
+                    "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
+                    "bottom": [0.0, 1.0, 2.0, 0.0, 1.0],
                 }
             ),
             does_not_raise(),
@@ -84,7 +84,7 @@ def test_validate_columns(df, columns, error, error_message):
     ],
 )
 def test_validate_monotony(df, error, error_message):
-    """Test if the ``Bottom`` of each ``PointID`` group is monotonically increasing."""
+    """Test if the ``bottom`` of each ``point_id`` group is monotonically increasing."""
     with error as e:
         GeotechPandasBase.validate_monotony(df)
         assert error_message is None or error_message in str(e)
@@ -96,18 +96,18 @@ def test_validate_monotony(df, error, error_message):
         (
             pd.DataFrame(
                 {
-                    "PointID": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
-                    "Bottom": [0.0, 1.0, 1.0, 0.0, 1.0],
+                    "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
+                    "bottom": [0.0, 1.0, 1.0, 0.0, 1.0],
                 }
             ),
             pytest.raises(AttributeError),
-            "The dataframe contains duplicate PointID and Bottom: BH-1.",
+            "The dataframe contains duplicate point_id and bottom: BH-1.",
         ),
         (
             pd.DataFrame(
                 {
-                    "PointID": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
-                    "Bottom": [0.0, 1.0, 2.0, 0.0, 1.0],
+                    "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
+                    "bottom": [0.0, 1.0, 2.0, 0.0, 1.0],
                 }
             ),
             does_not_raise(),
@@ -116,7 +116,7 @@ def test_validate_monotony(df, error, error_message):
     ],
 )
 def test_validate_duplicates(df, error, error_message):
-    """Test df for duplicate value pairs in the ``PointID`` and ``Bottom`` columns."""
+    """Test df for duplicate value pairs in the ``point_id`` and ``bottom`` columns."""
     with error as e:
         GeotechPandasBase.validate_duplicates(df)
         assert error_message is None or error_message in str(e)
@@ -126,29 +126,29 @@ def test_validate_duplicates(df, error, error_message):
     ("df", "error", "error_message"),
     [
         (
-            base_df[["PointID"]].copy(),
+            base_df[["point_id"]].copy(),
             pytest.raises(AttributeError),
-            "The dataframe must have: Bottom column.",
+            "The dataframe must have: bottom column.",
         ),
         (
             pd.DataFrame(
                 {
-                    "PointID": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
-                    "Bottom": [0.0, 2.0, 1.0, 0.0, 1.0],
+                    "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
+                    "bottom": [0.0, 2.0, 1.0, 0.0, 1.0],
                 }
             ),
             pytest.raises(AttributeError),
-            "Elements in the Bottom column must be monotonically increasing for: BH-1.",
+            "Elements in the bottom column must be monotonically increasing for: BH-1.",
         ),
         (
             pd.DataFrame(
                 {
-                    "PointID": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
-                    "Bottom": [0.0, 1.0, 1.0, 0.0, 1.0],
+                    "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2"],
+                    "bottom": [0.0, 1.0, 1.0, 0.0, 1.0],
                 }
             ),
             pytest.raises(AttributeError),
-            "The dataframe contains duplicate PointID and Bottom: BH-1.",
+            "The dataframe contains duplicate point_id and bottom: BH-1.",
         ),
         (
             base_df,

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -5,8 +5,8 @@ from geotech_pandas.point import PointDataFrameAccessor
 
 base_df = pd.DataFrame(
     {
-        "PointID": ["BH-1", "BH-1", "BH-2", "BH-2"],
-        "Bottom": [0.0, 1.0, 0.0, 1.0],
+        "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+        "bottom": [0.0, 1.0, 0.0, 1.0],
     }
 )
 
@@ -15,24 +15,24 @@ def test_groups():
     """Test if groups property returns a `DataFrameGroupBy` object."""
     df = PointDataFrameAccessor(base_df)
     g = df.groups
-    assert len(base_df["PointID"].unique()) == len(g)
+    assert len(base_df["point_id"].unique()) == len(g)
 
 
 def test_get_group():
     """Test if `get_group` returns the correct `DataFrame` object."""
     df = PointDataFrameAccessor(base_df)
-    for point_id in base_df["PointID"].to_list():
-        tm.assert_frame_equal(base_df[base_df["PointID"] == point_id], df.get_group(point_id))
+    for point_id in base_df["point_id"].to_list():
+        tm.assert_frame_equal(base_df[base_df["point_id"] == point_id], df.get_group(point_id))
 
 
 def test_get_top():
-    """Test if `get_top` returns correct shifted ``Bottom`` depths."""
+    """Test if `get_top` returns correct shifted ``bottom`` depths."""
     df = PointDataFrameAccessor(
         pd.DataFrame(
             {
-                "PointID": ["BH-1", "BH-1", "BH-2", "BH-2"],
-                "Bottom": [1.0, 2.0, 3.0, 4.0],
+                "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+                "bottom": [1.0, 2.0, 3.0, 4.0],
             }
         )
     )
-    tm.assert_series_equal(df.get_top(), pd.Series([0.0, 1.0, 0.0, 3.0], name="Top"))
+    tm.assert_series_equal(df.get_top(), pd.Series([0.0, 1.0, 0.0, 3.0], name="top"))


### PR DESCRIPTION
## Description
Rename column names to use snake case formatting for consistency. This means that ``PointID`` and ``Bottom`` are renamed to ``point_id`` and ``bottom``. Going forward, all column names should be in snake case to maintain consistency.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.