### PR TITLE
feat: add ability to get center depth values

### DIFF
--- a/src/geotech_pandas/point.py
+++ b/src/geotech_pandas/point.py
@@ -60,3 +60,14 @@ class PointDataFrameAccessor(GeotechPandasBase):
         """
         top = pd.Series(self.groups["bottom"].shift(1, fill_value=fill_value), name="top")
         return top
+
+    def get_center(self) -> pd.Series:
+        """Return ``center`` depth values from ``top`` and ``bottom`` depth values.
+
+        Returns
+        -------
+        Series
+            Series with ``center`` depth values.
+        """
+        self.validate_columns(self._obj, ["top", "bottom"])
+        return pd.Series(self._obj[["top", "bottom"]].mean(axis=1), name="center")

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -36,3 +36,17 @@ def test_get_top():
         )
     )
     tm.assert_series_equal(df.get_top(), pd.Series([0.0, 1.0, 0.0, 3.0], name="top"))
+
+
+def test_get_center():
+    """Test if `get_center` returns correct depth values."""
+    df = PointDataFrameAccessor(
+        pd.DataFrame(
+            {
+                "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+                "bottom": [1.0, 2.0, 3.0, 4.0],
+                "top": [0.0, 1.0, 0.0, 3.0],
+            }
+        )
+    )
+    tm.assert_series_equal(df.get_center(), pd.Series([0.5, 1.5, 1.5, 3.5], name="center"))


### PR DESCRIPTION
## Description
Add a `get_center` method to `PointDataFrameAccessor` that can be used to get the average of the ``top`` and ``bottom`` depth values.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.