### PR TITLE
feat: add ability to get thickness of depth values

### DIFF
--- a/src/geotech_pandas/point.py
+++ b/src/geotech_pandas/point.py
@@ -71,3 +71,14 @@ class PointDataFrameAccessor(GeotechPandasBase):
         """
         self.validate_columns(self._obj, ["top", "bottom"])
         return pd.Series(self._obj[["top", "bottom"]].mean(axis=1), name="center")
+
+    def get_thickness(self) -> pd.Series:
+        """Return ``thickness`` values of ``top`` and ``bottom`` depth values.
+
+        Returns
+        -------
+        Series
+            Series with ``thickness`` values.
+        """
+        self.validate_columns(self._obj, ["top", "bottom"])
+        return pd.Series((self._obj["bottom"] - self._obj["top"]).abs(), name="thickness")

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -50,3 +50,17 @@ def test_get_center():
         )
     )
     tm.assert_series_equal(df.get_center(), pd.Series([0.5, 1.5, 1.5, 3.5], name="center"))
+
+
+def test_get_thickness():
+    """Test if `get_thickness` returns correct values."""
+    df = PointDataFrameAccessor(
+        pd.DataFrame(
+            {
+                "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+                "bottom": [1.0, 2.0, 3.0, 4.0],
+                "top": [0.0, 1.0, 0.0, 3.0],
+            }
+        )
+    )
+    tm.assert_series_equal(df.get_thickness(), pd.Series([1.0, 1.0, 3.0, 1.0], name="thickness"))


### PR DESCRIPTION
## Description
Add a `get_thickness` method to `PointDataFrameAccessor` that can be used to get the difference between the ``top`` and ``bottom`` depth values.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.