### PR TITLE
feat: add ability to split layers

### DIFF
--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -64,3 +64,106 @@ def test_get_thickness():
         )
     )
     tm.assert_series_equal(df.get_thickness(), pd.Series([1.0, 1.0, 3.0, 1.0], name="thickness"))
+
+
+def test_split_at_depth_numeric():
+    """Test if `split_at_depth` with `depth` as a numeric value will return the correct result."""
+    expected = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2", "BH-2"],
+            "bottom": [0.5, 1.0, 2.0, 0.5, 3.0, 4.0],
+            "top": [0.0, 0.5, 1.0, 0.0, 0.5, 3.0],
+            "thickness": [1.0, 1.0, 1.0, 3.0, 3.0, 1.0],
+        }
+    )
+    result = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+            "top": [0.0, 1.0, 0.0, 3.0],
+            "thickness": [1.0, 1.0, 3.0, 1.0],
+        }
+    )
+    result = PointDataFrameAccessor(result).split_at_depth(depth=0.5)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_split_at_depth_series():
+    """Test if `split_at_depth` with `depth` as a series will return the correct result."""
+    expected = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2", "BH-2"],
+            "bottom": [0.5, 1.0, 2.0, 1.5, 3.0, 4.0],
+            "top": [0.0, 0.5, 1.0, 0.0, 1.5, 3.0],
+        }
+    )
+    result = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+            "top": [0.0, 1.0, 0.0, 3.0],
+        }
+    )
+    result = PointDataFrameAccessor(result).split_at_depth(depth=pd.Series([0.5, 0.5, 1.5, 1.5]))
+    tm.assert_frame_equal(result, expected)
+
+
+def test_split_at_depth_str():
+    """Test if `split_at_depth` with `depth` as a str value will return the correct result."""
+    expected = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2", "BH-2"],
+            "water_level": [0.5, 0.5, 0.5, 1.5, 1.5, 1.5],
+            "bottom": [0.5, 1.0, 2.0, 1.5, 3.0, 4.0],
+            "top": [0.0, 0.5, 1.0, 0.0, 1.5, 3.0],
+        }
+    )
+    result = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "water_level": [0.5, 0.5, 1.5, 1.5],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+            "top": [0.0, 1.0, 0.0, 3.0],
+        }
+    )
+    result = PointDataFrameAccessor(result).split_at_depth(depth="water_level")
+    tm.assert_frame_equal(result, expected)
+
+
+def test_split_at_depth_no_split():
+    """Test if `split_at_depth` where no splitting should happen will return the correct result."""
+    expected = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+            "top": [0.0, 1.0, 0.0, 3.0],
+            "thickness": [1.0, 1.0, 3.0, 1.0],
+        }
+    )
+    result = expected.copy()
+    result = PointDataFrameAccessor(result).split_at_depth(0)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_split_at_depth_no_index_reset():
+    """Test if `split_at_depth` with `reset_index` set to `True` will return the correct result.
+
+    The expected result should have the added layers take the original index of the split layers.
+    """
+    expected = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2", "BH-2"],
+            "bottom": [0.5, 1.0, 2.0, 0.5, 3.0, 4.0],
+            "top": [0.0, 0.5, 1.0, 0.0, 0.5, 3.0],
+        },
+        index=[0, 0, 1, 2, 2, 3],
+    )
+    result = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+            "top": [0.0, 1.0, 0.0, 3.0],
+        }
+    )
+    result = PointDataFrameAccessor(result).split_at_depth(depth=0.5, reset_index=False)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Description
Add a `split_at_depth` method to `PointDataFrameAccessor` that can be used to split layers in the dataframe into two with the provided depth.

If the provided depth is found in between the ``top`` and ``bottom`` columns of the dataframe, then those particular layers would be split. The ``top`` and ``bottom`` depths of the affected layers are also adjusted to have continuity after splitting. However, columns other than ``top`` and ``bottom`` are not modified.

This is particularly useful for cases where it is required or beneficial to split layers into two. For example, splitting a layer that is partly saturated and partly dry due to the groundwater level being found inside the layer.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.