### PR TITLE
feat: register dataframe accessor as `geotech`

### DIFF
--- a/src/geotech_pandas/accessor.py
+++ b/src/geotech_pandas/accessor.py
@@ -1,0 +1,14 @@
+"""General dataframe accessor class for the Geotech Pandas package."""
+
+import pandas as pd
+
+from geotech_pandas.point import PointDataFrameAccessor
+
+
+@pd.api.extensions.register_dataframe_accessor("geotech")
+class GeotechDataFrameAccessor:
+    """DataFrame accessor that provides namespaces to the various accessors in Geotech Pandas."""
+
+    def __init__(self, df: pd.DataFrame):
+        self.point: PointDataFrameAccessor = PointDataFrameAccessor(df)
+        """Accessor for depth-related points."""

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,0 +1,47 @@
+"""Test if accessors are registered with their namespaces as expected."""
+from functools import reduce
+
+import pandas as pd
+import pytest
+
+import geotech_pandas.accessor  # noqa: F401
+from geotech_pandas.accessor import GeotechDataFrameAccessor
+from geotech_pandas.point import PointDataFrameAccessor
+
+
+@pytest.fixture()
+def df():
+    """Return default dataframe for testing."""
+    return pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("namespaces", "accessor"),
+    [
+        (["geotech"], GeotechDataFrameAccessor),
+        (["geotech", "point"], PointDataFrameAccessor),
+    ],
+)
+def test_dataframe_accessor(df, namespaces, accessor):
+    """Test if the last element of `namespace` is a registered `accessor` in a `DataFrame` object.
+
+    The `namespace` list is reduced. This means that providing a list of ``["a", "b"]`` would mean
+    that the attribute `a` would first be obtained from `df`, then the attribute `b` would be
+    obtained from `a`. Where `b` would then be checked if it is an instance of `accessor`.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Dataframe checked for registered accessors.
+    namespaces : list of str
+        Namespaces or attributes to be reduced, with the last element checked for the equivalent
+        accessor.
+    accessor : class
+        Equivalent accessor class of the given namespace.
+    """
+    assert isinstance(reduce(getattr, namespaces, df), accessor)


### PR DESCRIPTION
## Description
Registers a DataFrame accessor that provides namespaces to the various accessors in Geotech Pandas.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.