### PR TITLE
feat(utils): add sub-accessor object for auto-documentation

### DIFF
--- a/docs/user_guide/basics.rst
+++ b/docs/user_guide/basics.rst
@@ -3,9 +3,9 @@
 ======
 Basics
 ======
-:mod:`geotech-pandas` is mainly accessed from the ``geotech`` accessor on
-:external:py:class:`DataFrame <pandas.DataFrame>` objects. When accessed, :mod:`geotech-pandas`
-validates the current :external:py:class:`DataFrame <pandas.DataFrame>` for several minimum
+:mod:`geotech-pandas` is mainly accessed from the :py:class:`~pandas.DataFrame.geotech` accessor on
+:external:py:class:`~pandas.DataFrame` objects. When accessed, :mod:`geotech-pandas`
+validates the current :external:py:class:`~pandas.DataFrame` for several minimum
 requirements. These requirements are discussed in the following sections.
 
 Customarily, we import as follows before we begin the guide,
@@ -13,7 +13,7 @@ Customarily, we import as follows before we begin the guide,
 .. ipython:: python
 
     import pandas as pd
-    import geotech_pandas.accessor
+    import geotech_pandas
 
 Required Columns
 ----------------
@@ -21,8 +21,8 @@ The minimum required columns for :mod:`geotech-pandas` are the ``point_id`` and 
 The ``point_id`` represents the ID or the group where each observation or soil layer belongs to.
 Whereas, the ``bottom`` column represents the bottom depths of these observations.
 
-If you try to access ``geotech`` with the following
-:external:py:class:`DataFrame <pandas.DataFrame>`,
+If you try to access :py:class:`~pandas.DataFrame.geotech` with the following
+:external:py:class:`~pandas.DataFrame`,
 
 .. ipython:: python
     :okexcept:
@@ -32,10 +32,10 @@ If you try to access ``geotech`` with the following
             "point_id": ["BH-1", "BH-1", "BH-1"],
         }
     )
-    df.geotech
+    df.geotech()
 
 An :external:py:class:`AttributeError` is raised stating that the
-:external:py:class:`DataFrame <pandas.DataFrame>` is missing the ``bottom`` column.
+:external:py:class:`~pandas.DataFrame` is missing the ``bottom`` column.
 
 Required Arrangement
 --------------------
@@ -43,8 +43,8 @@ Required Arrangement
 monotonically increasing, as most methods assume that each layer comes right after the other in each
 point.
 
-If you try to access ``geotech`` with the following
-:external:py:class:`DataFrame <pandas.DataFrame>`,
+If you try to access :py:class:`~pandas.DataFrame.geotech` with the following
+:external:py:class:`~pandas.DataFrame`,
 
 .. ipython:: python
     :okexcept:
@@ -55,7 +55,7 @@ If you try to access ``geotech`` with the following
             "bottom": [0.0, 2.0, 1.0],
         }
     )
-    df.geotech
+    df.geotech()
 
 An :external:py:class:`AttributeError` is raised listing which points contain the erroneous
 arrangement.
@@ -65,8 +65,8 @@ Required Uniqueness
 :mod:`geotech-pandas` requires ``point_id`` and ``bottom`` pairs to be unique, as most methods
 assume that each layer is unique for each point.
 
-If you try to access ``geotech`` with the following
-:external:py:class:`DataFrame <pandas.DataFrame>`,
+If you try to access :py:class:`~pandas.DataFrame.geotech` with the following
+:external:py:class:`~pandas.DataFrame`,
 
 .. ipython:: python
     :okexcept:
@@ -77,18 +77,19 @@ If you try to access ``geotech`` with the following
             "bottom": [0.0, 1.0, 1.0],
         }
     )
-    df.geotech
+    df.geotech()
 
 An :external:py:class:`AttributeError` is raised listing which points contain duplicate values.
 
 Subaccessors
 ------------
-There are no available methods under the ``geotech`` accessor other than the validation methods
-that are called automatically upon initiation of the accessor as shown in the preceding sections.
+There are no available methods under the :py:class:`~pandas.DataFrame.geotech` accessor other than
+the validation methods that are called automatically upon initiation of the accessor as shown in the
+preceding sections.
 
-The ``geotech`` accessor serves as a parent namespace to the various scopes provided in
-:mod:`geotech-pandas`. These scopes are accessors that can be accessed from ``geotech`` like
-so,
+The :py:class:`~pandas.DataFrame.geotech` accessor serves as a parent namespace to the various
+scopes provided in :mod:`geotech-pandas`. These scopes are accessors that can be accessed from
+:py:class:`~pandas.DataFrame.geotech` like so,
 
 .. ipython:: python
 
@@ -100,5 +101,6 @@ so,
     )
     df.geotech.point
 
-Here, we can access the ``point`` accessor where depth-related calculations can be accessed.
-Head to the related :ref:`guide <point>` for more information about the ``point`` accessor.
+Here, we can access the :py:class:`~pandas.DataFrame.geotech.point` accessor where depth-related
+calculations can be accessed. Head to the related :ref:`guide <point>` for more information about
+the :py:class:`~pandas.DataFrame.geotech.point` accessor.

--- a/src/geotech_pandas/accessor.py
+++ b/src/geotech_pandas/accessor.py
@@ -1,14 +1,23 @@
-"""General dataframe accessor class for the Geotech Pandas package."""
+"""General :external:class:`~pandas.DataFrame` accessor for the :mod:`geotech-pandas` package."""
 
 import pandas as pd
 
+from geotech_pandas.base import GeotechPandasBase
 from geotech_pandas.point import PointDataFrameAccessor
+from geotech_pandas.utils import SubAccessor
 
 
 @pd.api.extensions.register_dataframe_accessor("geotech")
-class GeotechDataFrameAccessor:
-    """DataFrame accessor that provides namespaces to the various accessors in Geotech Pandas."""
+class GeotechDataFrameAccessor(GeotechPandasBase):
+    """:external:class:`~pandas.DataFrame` accessor that provides namespaces to the various
+    subaccessors in :mod:`geotech-pandas`.
+    """  # noqa: D205
+
+    point = SubAccessor(PointDataFrameAccessor)
 
     def __init__(self, df: pd.DataFrame):
-        self.point: PointDataFrameAccessor = PointDataFrameAccessor(df)
-        """Accessor for depth-related points."""
+        self._obj = df
+
+        self._validate_columns()
+        self._validate_monotony()
+        self._validate_duplicates()

--- a/src/geotech_pandas/point.py
+++ b/src/geotech_pandas/point.py
@@ -1,4 +1,4 @@
-"""A module containing a custom accessor for pandas that adds methods for depth related points."""
+"""Subaccessor that contains methods for depth-related points."""
 
 from typing import Union
 
@@ -10,30 +10,32 @@ from geotech_pandas.base import GeotechPandasBase
 
 class PointDataFrameAccessor(GeotechPandasBase):
     """
-    An accessor class that contains methods for depth-related points.
+    Subaccessor that contains methods for depth-related points.
 
-    The dataframe should have ``point_id`` and ``bottom`` columns, where ``point_id`` would signify
-    what group the ``bottom`` depths and other related data belong to. These groups can be accessed
-    as a `DataFrameGroupBy` object through the `groups` property.
+    The :external:class:`~pandas.DataFrame` should have ``point_id`` and ``bottom`` columns, where
+    ``point_id`` would signify what group the ``bottom`` depths and other related data belong to.
+    These groups can be accessed as a :external:class:`~pandas.api.typing.DataFrameGroupBy` object
+    through the :attr:`~DataFrame.geotech.point.groups` property.
     """
 
     @property
     def groups(self) -> DataFrameGroupBy:
         """
-        Return a pandas `DataFrameGroupBy` object based on the ``point_id`` column.
+        Return a :external:class:`~pandas.api.typing.DataFrameGroupBy` object based on the
+        ``point_id`` column.
 
         This can be used a shortcut for grouping the dataframe by the ``point_id``.
 
         Returns
         -------
-        DataFrameGroupBy
-            GroupBy object that contains the grouped dataframes.
-        """
+        :external:class:`~pandas.api.typing.DataFrameGroupBy`
+            GroupBy object that contains the grouped DataFrames.
+        """  # noqa: D205
         return self._obj.groupby("point_id")
 
     def get_group(self, point_id: str):
         """
-        Return a `DataFrame` from the point groups with provided `point_id`.
+        Return a :external:class:`~pandas.DataFrame` from the point groups with provided `point_id`.
 
         Parameters
         ----------
@@ -42,7 +44,7 @@ class PointDataFrameAccessor(GeotechPandasBase):
 
         Returns
         -------
-        DataFrame
+        :external:class:`~pandas.DataFrame`
             DataFrame that matches `point_id`.
         """
         return self.groups.get_group(point_id)
@@ -57,7 +59,7 @@ class PointDataFrameAccessor(GeotechPandasBase):
 
         Returns
         -------
-        Series
+        :external:class:`~pandas.Series`
             Series with shifted ``bottom`` values.
         """
         top = pd.Series(self.groups["bottom"].shift(1, fill_value=fill_value), name="top")
@@ -68,10 +70,10 @@ class PointDataFrameAccessor(GeotechPandasBase):
 
         Returns
         -------
-        Series
+        :external:class:`~pandas.Series`
             Series with ``center`` depth values.
         """
-        self.validate_columns(self._obj, ["top", "bottom"])
+        self._validate_columns(["top", "bottom"])
         return pd.Series(self._obj[["top", "bottom"]].mean(axis=1), name="center")
 
     def get_thickness(self) -> pd.Series:
@@ -79,10 +81,10 @@ class PointDataFrameAccessor(GeotechPandasBase):
 
         Returns
         -------
-        Series
+        :external:class:`~pandas.Series`
             Series with ``thickness`` values.
         """
-        self.validate_columns(self._obj, ["top", "bottom"])
+        self._validate_columns(["top", "bottom"])
         return pd.Series((self._obj["bottom"] - self._obj["top"]).abs(), name="thickness")
 
     def split_at_depth(
@@ -104,14 +106,14 @@ class PointDataFrameAccessor(GeotechPandasBase):
 
         Parameters
         ----------
-        depth: pandas.Series, float, int, or str
+        depth: Series, float, int, or str
             The depth/s where the layer would be split.
         reset_index: bool, default True
             If `True`, resets the index after splitting.
 
         Returns
         -------
-        DataFrame
+        :external:class:`~pandas.DataFrame`
             Dataframe with added and modified values for applicable layer splits. If no applicable
             splits are found, then the original dataframe is returned instead.
         """
@@ -120,7 +122,7 @@ class PointDataFrameAccessor(GeotechPandasBase):
             depth = self._obj[depth]
         else:
             validation_list = ["top"]
-        self.validate_columns(self._obj, validation_list)
+        self._validate_columns(validation_list)
 
         temp = self._obj.loc[(self._obj["top"] < depth) & (depth < self._obj["bottom"])].copy(
             deep=True
@@ -132,5 +134,5 @@ class PointDataFrameAccessor(GeotechPandasBase):
         temp = temp.sort_values(["point_id", "bottom"])
         if reset_index:
             temp = temp.reset_index(drop=True)
-        temp["top"] = PointDataFrameAccessor(temp).get_top()
+        temp["top"] = temp.geotech.point.get_top()
         return temp

--- a/src/geotech_pandas/utils.py
+++ b/src/geotech_pandas/utils.py
@@ -1,0 +1,17 @@
+"""Internal utilities."""
+
+
+class SubAccessor:
+    """A property-like object for both classes and class instances.
+
+    This is required for sphinx autodoc to work correctly on sub-accessors.
+    """
+
+    def __init__(self, accessor) -> None:
+        self._accessor = accessor
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self._accessor
+
+        return self._accessor(obj)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pandas._testing as tm
 import pytest
 
-from geotech_pandas.base import GeotechPandasBase
+import geotech_pandas  # noqa: F401
 
 base_df = pd.DataFrame(
     {
@@ -18,8 +18,8 @@ base_df = pd.DataFrame(
 
 def test_obj():
     """Test if dataframe is stored in ``_obj``."""
-    gpdf = GeotechPandasBase(base_df)
-    tm.assert_frame_equal(base_df, gpdf._obj)
+    df = base_df
+    tm.assert_frame_equal(base_df, df.geotech._obj)
 
 
 @pytest.mark.parametrize(
@@ -54,7 +54,7 @@ def test_obj():
 def test_validate_columns(df, columns, error, error_message):
     """Test if columns are in df else raise error with error_message."""
     with error as e:
-        GeotechPandasBase.validate_columns(df, columns)
+        df.geotech._validate_columns(columns)
         assert error_message is None or error_message in str(e)
 
 
@@ -86,7 +86,7 @@ def test_validate_columns(df, columns, error, error_message):
 def test_validate_monotony(df, error, error_message):
     """Test if the ``bottom`` of each ``point_id`` group is monotonically increasing."""
     with error as e:
-        GeotechPandasBase.validate_monotony(df)
+        df.geotech._validate_monotony()
         assert error_message is None or error_message in str(e)
 
 
@@ -118,7 +118,7 @@ def test_validate_monotony(df, error, error_message):
 def test_validate_duplicates(df, error, error_message):
     """Test df for duplicate value pairs in the ``point_id`` and ``bottom`` columns."""
     with error as e:
-        GeotechPandasBase.validate_duplicates(df)
+        df.geotech._validate_duplicates()
         assert error_message is None or error_message in str(e)
 
 
@@ -157,8 +157,8 @@ def test_validate_duplicates(df, error, error_message):
         ),
     ],
 )
-def test_validatorsj(df, error, error_message):
+def test_validators(df, error, error_message):
     """Test if validators are triggered for wrong dataframe configurations."""
     with error as e:
-        GeotechPandasBase(df)
+        df.geotech  # noqa: B018
         assert error_message is None or error_message in str(e)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pandas._testing as tm
 
-from geotech_pandas.point import PointDataFrameAccessor
+import geotech_pandas
 
 base_df = pd.DataFrame(
     {
@@ -11,59 +11,64 @@ base_df = pd.DataFrame(
 )
 
 
+def test_accessor():
+    """Test if accessor is registered correctly."""
+    isinstance(pd.DataFrame.geotech.point, geotech_pandas.point.PointDataFrameAccessor)
+
+
 def test_groups():
     """Test if groups property returns a `DataFrameGroupBy` object."""
-    df = PointDataFrameAccessor(base_df)
-    g = df.groups
+    df = base_df
+    g = df.geotech.point.groups
     assert len(base_df["point_id"].unique()) == len(g)
 
 
 def test_get_group():
     """Test if `get_group` returns the correct `DataFrame` object."""
-    df = PointDataFrameAccessor(base_df)
+    df = base_df
     for point_id in base_df["point_id"].to_list():
-        tm.assert_frame_equal(base_df[base_df["point_id"] == point_id], df.get_group(point_id))
+        tm.assert_frame_equal(
+            base_df[base_df["point_id"] == point_id], df.geotech.point.get_group(point_id)
+        )
 
 
 def test_get_top():
     """Test if `get_top` returns correct shifted ``bottom`` depths."""
-    df = PointDataFrameAccessor(
-        pd.DataFrame(
-            {
-                "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
-                "bottom": [1.0, 2.0, 3.0, 4.0],
-            }
-        )
+    df = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+        }
     )
-    tm.assert_series_equal(df.get_top(), pd.Series([0.0, 1.0, 0.0, 3.0], name="top"))
+    tm.assert_series_equal(df.geotech.point.get_top(), pd.Series([0.0, 1.0, 0.0, 3.0], name="top"))
 
 
 def test_get_center():
     """Test if `get_center` returns correct depth values."""
-    df = PointDataFrameAccessor(
-        pd.DataFrame(
-            {
-                "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
-                "bottom": [1.0, 2.0, 3.0, 4.0],
-                "top": [0.0, 1.0, 0.0, 3.0],
-            }
-        )
+    df = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+            "top": [0.0, 1.0, 0.0, 3.0],
+        }
     )
-    tm.assert_series_equal(df.get_center(), pd.Series([0.5, 1.5, 1.5, 3.5], name="center"))
+    tm.assert_series_equal(
+        df.geotech.point.get_center(), pd.Series([0.5, 1.5, 1.5, 3.5], name="center")
+    )
 
 
 def test_get_thickness():
     """Test if `get_thickness` returns correct values."""
-    df = PointDataFrameAccessor(
-        pd.DataFrame(
-            {
-                "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
-                "bottom": [1.0, 2.0, 3.0, 4.0],
-                "top": [0.0, 1.0, 0.0, 3.0],
-            }
-        )
+    df = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
+            "bottom": [1.0, 2.0, 3.0, 4.0],
+            "top": [0.0, 1.0, 0.0, 3.0],
+        }
     )
-    tm.assert_series_equal(df.get_thickness(), pd.Series([1.0, 1.0, 3.0, 1.0], name="thickness"))
+    tm.assert_series_equal(
+        df.geotech.point.get_thickness(), pd.Series([1.0, 1.0, 3.0, 1.0], name="thickness")
+    )
 
 
 def test_split_at_depth_numeric():
@@ -84,7 +89,7 @@ def test_split_at_depth_numeric():
             "thickness": [1.0, 1.0, 3.0, 1.0],
         }
     )
-    result = PointDataFrameAccessor(result).split_at_depth(depth=0.5)
+    result = result.geotech.point.split_at_depth(depth=0.5)
     tm.assert_frame_equal(result, expected)
 
 
@@ -104,7 +109,7 @@ def test_split_at_depth_series():
             "top": [0.0, 1.0, 0.0, 3.0],
         }
     )
-    result = PointDataFrameAccessor(result).split_at_depth(depth=pd.Series([0.5, 0.5, 1.5, 1.5]))
+    result = result.geotech.point.split_at_depth(depth=pd.Series([0.5, 0.5, 1.5, 1.5]))
     tm.assert_frame_equal(result, expected)
 
 
@@ -126,7 +131,7 @@ def test_split_at_depth_str():
             "top": [0.0, 1.0, 0.0, 3.0],
         }
     )
-    result = PointDataFrameAccessor(result).split_at_depth(depth="water_level")
+    result = result.geotech.point.split_at_depth(depth="water_level")
     tm.assert_frame_equal(result, expected)
 
 
@@ -141,7 +146,7 @@ def test_split_at_depth_no_split():
         }
     )
     result = expected.copy()
-    result = PointDataFrameAccessor(result).split_at_depth(0)
+    result = result.geotech.point.split_at_depth(0)
     tm.assert_frame_equal(result, expected)
 
 
@@ -165,5 +170,5 @@ def test_split_at_depth_no_index_reset():
             "top": [0.0, 1.0, 0.0, 3.0],
         }
     )
-    result = PointDataFrameAccessor(result).split_at_depth(depth=0.5, reset_index=False)
+    result = result.geotech.point.split_at_depth(depth=0.5, reset_index=False)
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Description
The `SubAccessor` class is used to register accessors in accessors. This is also needed to properly generate documentation using `sphinx.ext.autodoc`.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.