### PR TITLE
docs: improve consistency of terms and cross-references

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -4,7 +4,7 @@
   "checkout": null,
   "context": {
     "cookiecutter": {
-      "package_name": "Geotech Pandas",
+      "package_name": "geotech-pandas",
       "package_description": "A Pandas extension for geotechnical calculations.",
       "package_url": "https://github.com/fraserdominicdavid/geotech-pandas",
       "author_name": "Fraser Dominic David",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/fraserdominicdavid/geotech-pandas)
 
-# Geotech Pandas
+# geotech-pandas
 
 A Pandas extension for geotechnical calculations.
 

--- a/src/geotech_pandas/__init__.py
+++ b/src/geotech_pandas/__init__.py
@@ -1,4 +1,4 @@
-"""Geotech Pandas package."""
+"""geotech-pandas package."""
 
 from geotech_pandas.accessor import GeotechDataFrameAccessor
 

--- a/src/geotech_pandas/base.py
+++ b/src/geotech_pandas/base.py
@@ -18,27 +18,24 @@ class GeotechPandasBase:
 
     def _validate_columns(self, columns: Optional[list[str]] = None) -> None:
         """
-        Validate the dataframe if it contains the columns from a provided list.
+        Validate if the :external:class:`~pandas.DataFrame` contains the columns from a provided
+        list.
 
-        The `_validate_columns` method is a static method that is used to validate the columns of a
-        given dataframe. The method takes in a dataframe and a list of columns to be validated. If
-        the validation list is not provided, the method defaults to checking if the ``point_id`` and
-        ``bottom`` columns are present in the dataframe. If any of the columns in the validation
-        list are not found in the dataframe, the method raises an `AttributeError` and lists the
-        missing columns in the error message.
+        If the validation list is not provided, the method defaults to checking if the ``point_id``
+        and ``bottom`` columns are present in the :external:class:`~pandas.DataFrame`. If any of the
+        columns in the validation list are not found in the :external:class:`~pandas.DataFrame`, the
+        method raises an ``AttributeError`` and lists the missing columns in the error message.
 
         Parameters
         ----------
-        df : pandas.DataFrame
-            Dataframe to be validated.
         columns : list of str, optional, default ["point_id", "bottom"]
             List of column names to be validated.
 
         Raises
         ------
         AttributeError
-            When any of the columns in the validation list are not found in the dataframe.
-        """
+            When any of the columns in the validation list are not found in the DataFrame.
+        """  # noqa: D205
         if columns is None:
             columns = ["point_id", "bottom"]
 
@@ -49,18 +46,13 @@ class GeotechPandasBase:
 
         if len(missing_columns) > 0:
             raise AttributeError(
-                f"The dataframe must have: {', '.join(missing_columns)} "
+                f"The DataFrame must have: {', '.join(missing_columns)} "
                 f"column{'s' if len(missing_columns) > 1 else ''}."
             )
 
     def _validate_monotony(self) -> None:
         """
         Validate if the ``bottom`` of each ``point_id`` group is monotonically increasing.
-
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            Dataframe to be validated.
 
         Raises
         ------
@@ -78,23 +70,19 @@ class GeotechPandasBase:
 
     def _validate_duplicates(self) -> None:
         """
-        Validate the dataframe for duplicate value pairs in the ``point_id`` and ``bottom`` columns.
-
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            Dataframe to be validated.
+        Validate the :external:class:`~pandas.DataFrame` for duplicate value pairs in the
+        ``point_id`` and ``bottom`` columns.
 
         Raises
         ------
         AttributeError
             When duplicate value pairs in the ``point_id`` and ``bottom`` columns are detected.
-        """
+        """  # noqa: D205
         duplicate_list = self._obj[self._obj[["point_id", "bottom"]].duplicated()][
             "point_id"
         ].to_list()
         if len(duplicate_list) > 0:
             raise AttributeError(
-                "The dataframe contains duplicate point_id and bottom:"
+                "The DataFrame contains duplicate point_id and bottom:"
                 f" {', '.join(duplicate_list)}."
             )

--- a/src/geotech_pandas/point.py
+++ b/src/geotech_pandas/point.py
@@ -24,18 +24,20 @@ class PointDataFrameAccessor(GeotechPandasBase):
         Return a :external:class:`~pandas.api.typing.DataFrameGroupBy` object based on the
         ``point_id`` column.
 
-        This can be used a shortcut for grouping the dataframe by the ``point_id``.
+        This can be used as a shortcut for grouping the :external:class:`~pandas.DataFrame` by the
+        ``point_id``.
 
         Returns
         -------
         :external:class:`~pandas.api.typing.DataFrameGroupBy`
-            GroupBy object that contains the grouped DataFrames.
+            GroupBy object that contains the grouped DataFrame objects.
         """  # noqa: D205
         return self._obj.groupby("point_id")
 
     def get_group(self, point_id: str):
         """
-        Return a :external:class:`~pandas.DataFrame` from the point groups with provided `point_id`.
+        Return a :external:class:`~pandas.DataFrame` from the point groups with matching
+        ``point_id``.
 
         Parameters
         ----------
@@ -45,8 +47,8 @@ class PointDataFrameAccessor(GeotechPandasBase):
         Returns
         -------
         :external:class:`~pandas.DataFrame`
-            DataFrame that matches `point_id`.
-        """
+            DataFrame that matches ``point_id``.
+        """  # noqa: D205
         return self.groups.get_group(point_id)
 
     def get_top(self, fill_value: float = 0.0) -> pd.Series:
@@ -90,10 +92,10 @@ class PointDataFrameAccessor(GeotechPandasBase):
     def split_at_depth(
         self, depth: Union[pd.Series, float, int, str], reset_index: bool = True
     ) -> pd.DataFrame:
-        """Split layers in the dataframe into two with the provided depth.
+        """Split layers in the :external:class:`~pandas.DataFrame` into two with the provided depth.
 
         If the provided depth is found in between the ``top`` and ``bottom`` columns of the
-        dataframe, then those particular layers would be split.
+        :external:class:`~pandas.DataFrame`, then those particular layers would be split.
 
         The ``top`` and ``bottom`` depths of the affected layers are also adjusted to have
         continuity after splitting. However, columns other than ``top`` and ``bottom`` are not
@@ -114,8 +116,8 @@ class PointDataFrameAccessor(GeotechPandasBase):
         Returns
         -------
         :external:class:`~pandas.DataFrame`
-            Dataframe with added and modified values for applicable layer splits. If no applicable
-            splits are found, then the original dataframe is returned instead.
+            DataFrame with added and modified values for applicable layer splits. If no applicable
+            splits are found, then the original DataFrame is returned instead.
         """
         if isinstance(depth, str):
             validation_list = [depth, "top"]

--- a/src/geotech_pandas/utils.py
+++ b/src/geotech_pandas/utils.py
@@ -4,7 +4,7 @@
 class SubAccessor:
     """A property-like object for both classes and class instances.
 
-    This is required for sphinx autodoc to work correctly on sub-accessors.
+    This is required for sphinx autodoc to work correctly on subaccessors.
     """
 
     def __init__(self, accessor) -> None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Geotech Pandas test suite."""
+"""geotech-pandas test suite."""

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -4,14 +4,14 @@ from functools import reduce
 import pandas as pd
 import pytest
 
-import geotech_pandas.accessor  # noqa: F401
+import geotech_pandas  # noqa: F401
 from geotech_pandas.accessor import GeotechDataFrameAccessor
 from geotech_pandas.point import PointDataFrameAccessor
 
 
 @pytest.fixture()
 def df():
-    """Return default dataframe for testing."""
+    """Return default ``DataFrame`` for testing."""
     return pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
@@ -28,16 +28,16 @@ def df():
     ],
 )
 def test_dataframe_accessor(df, namespaces, accessor):
-    """Test if the last element of `namespace` is a registered `accessor` in a `DataFrame` object.
+    """Test if the last element of ``namespace`` is a registered ``accessor`` in ``df``.
 
-    The `namespace` list is reduced. This means that providing a list of ``["a", "b"]`` would mean
-    that the attribute `a` would first be obtained from `df`, then the attribute `b` would be
-    obtained from `a`. Where `b` would then be checked if it is an instance of `accessor`.
+    The ``namespace`` list is reduced. This means that providing a list of ``["a", "b"]`` would mean
+    that the attribute ``a`` would first be obtained from ``df``, then the attribute ``b`` would be
+    obtained from ``a``. Where ``b`` would then be checked if it is an instance of ``accessor``.
 
     Parameters
     ----------
-    df : pandas.DataFrame
-        Dataframe checked for registered accessors.
+    df : DataFrame
+        DataFrame checked for registered accessors.
     namespaces : list of str
         Namespaces or attributes to be reduced, with the last element checked for the equivalent
         accessor.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,7 +17,7 @@ base_df = pd.DataFrame(
 
 
 def test_obj():
-    """Test if dataframe is stored in ``_obj``."""
+    """Test if the ``DataFrame`` is stored in ``_obj``."""
     df = base_df
     tm.assert_frame_equal(base_df, df.geotech._obj)
 
@@ -29,19 +29,19 @@ def test_obj():
             base_df[["point_id"]].copy(),
             None,
             pytest.raises(AttributeError),
-            "The dataframe must have: bottom column.",
+            "The DataFrame must have: bottom column.",
         ),
         (
             base_df[["point_id"]].copy(),
             ["point_id", "top", "bottom"],
             pytest.raises(AttributeError),
-            "The dataframe must have: top, bottom columns.",
+            "The DataFrame must have: top, bottom columns.",
         ),
         (
             base_df,
             ["point_id", "top", "bottom"],
             pytest.raises(AttributeError),
-            "The dataframe must have: top column.",
+            "The DataFrame must have: top column.",
         ),
         (
             base_df,
@@ -52,7 +52,7 @@ def test_obj():
     ],
 )
 def test_validate_columns(df, columns, error, error_message):
-    """Test if columns are in df else raise error with error_message."""
+    """Test if ``columns`` are in ``df`` else raise ``error`` with ``error_message``."""
     with error as e:
         df.geotech._validate_columns(columns)
         assert error_message is None or error_message in str(e)
@@ -101,7 +101,7 @@ def test_validate_monotony(df, error, error_message):
                 }
             ),
             pytest.raises(AttributeError),
-            "The dataframe contains duplicate point_id and bottom: BH-1.",
+            "The DataFrame contains duplicate point_id and bottom: BH-1.",
         ),
         (
             pd.DataFrame(
@@ -116,7 +116,7 @@ def test_validate_monotony(df, error, error_message):
     ],
 )
 def test_validate_duplicates(df, error, error_message):
-    """Test df for duplicate value pairs in the ``point_id`` and ``bottom`` columns."""
+    """Test ``DataFrame`` for duplicate value pairs in the ``point_id`` and ``bottom`` columns."""
     with error as e:
         df.geotech._validate_duplicates()
         assert error_message is None or error_message in str(e)
@@ -128,7 +128,7 @@ def test_validate_duplicates(df, error, error_message):
         (
             base_df[["point_id"]].copy(),
             pytest.raises(AttributeError),
-            "The dataframe must have: bottom column.",
+            "The DataFrame must have: bottom column.",
         ),
         (
             pd.DataFrame(
@@ -148,7 +148,7 @@ def test_validate_duplicates(df, error, error_message):
                 }
             ),
             pytest.raises(AttributeError),
-            "The dataframe contains duplicate point_id and bottom: BH-1.",
+            "The DataFrame contains duplicate point_id and bottom: BH-1.",
         ),
         (
             base_df,
@@ -158,7 +158,7 @@ def test_validate_duplicates(df, error, error_message):
     ],
 )
 def test_validators(df, error, error_message):
-    """Test if validators are triggered for wrong dataframe configurations."""
+    """Test if validators are triggered for wrong ``DataFrame`` configurations."""
     with error as e:
         df.geotech  # noqa: B018
         assert error_message is None or error_message in str(e)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,4 @@
-"""Test Geotech Pandas."""
+"""Test geotech-pandas."""
 
 import geotech_pandas
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,3 +1,4 @@
+"""Test ``point`` subaccessor methods."""
 import pandas as pd
 import pandas._testing as tm
 
@@ -17,14 +18,14 @@ def test_accessor():
 
 
 def test_groups():
-    """Test if groups property returns a `DataFrameGroupBy` object."""
+    """Test if groups property returns a ``DataFrameGroupBy`` object."""
     df = base_df
     g = df.geotech.point.groups
     assert len(base_df["point_id"].unique()) == len(g)
 
 
 def test_get_group():
-    """Test if `get_group` returns the correct `DataFrame` object."""
+    """Test if ``get_group`` returns the correct ``DataFrame`` object."""
     df = base_df
     for point_id in base_df["point_id"].to_list():
         tm.assert_frame_equal(
@@ -33,7 +34,7 @@ def test_get_group():
 
 
 def test_get_top():
-    """Test if `get_top` returns correct shifted ``bottom`` depths."""
+    """Test if ``get_top`` returns the correct shifted ``bottom`` depths."""
     df = pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
@@ -44,7 +45,7 @@ def test_get_top():
 
 
 def test_get_center():
-    """Test if `get_center` returns correct depth values."""
+    """Test if ``get_center`` returns the correct values."""
     df = pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
@@ -58,7 +59,7 @@ def test_get_center():
 
 
 def test_get_thickness():
-    """Test if `get_thickness` returns correct values."""
+    """Test if ``get_thickness`` returns the correct values."""
     df = pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
@@ -72,7 +73,9 @@ def test_get_thickness():
 
 
 def test_split_at_depth_numeric():
-    """Test if `split_at_depth` with `depth` as a numeric value will return the correct result."""
+    """Test if ``split_at_depth`` with ``depth`` as a numeric value will return the correct
+    result.
+    """  # noqa: D205
     expected = pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2", "BH-2"],
@@ -94,7 +97,7 @@ def test_split_at_depth_numeric():
 
 
 def test_split_at_depth_series():
-    """Test if `split_at_depth` with `depth` as a series will return the correct result."""
+    """Test if ``split_at_depth`` with ``depth`` as a ``Series`` will return the correct result."""
     expected = pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2", "BH-2"],
@@ -114,7 +117,9 @@ def test_split_at_depth_series():
 
 
 def test_split_at_depth_str():
-    """Test if `split_at_depth` with `depth` as a str value will return the correct result."""
+    """Test if ``split_at_depth`` with ``depth`` as a ``str`` value will return the correct
+    result.
+    """  # noqa: D205
     expected = pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2", "BH-2"],
@@ -136,7 +141,9 @@ def test_split_at_depth_str():
 
 
 def test_split_at_depth_no_split():
-    """Test if `split_at_depth` where no splitting should happen will return the correct result."""
+    """Test if ``split_at_depth`` where no splitting should happen will return the correct
+    result.
+    """  # noqa: D205
     expected = pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-2", "BH-2"],
@@ -151,10 +158,11 @@ def test_split_at_depth_no_split():
 
 
 def test_split_at_depth_no_index_reset():
-    """Test if `split_at_depth` with `reset_index` set to `True` will return the correct result.
+    """Test if ``split_at_depth`` with ``reset_index`` set to ``True`` will return the correct
+    result.
 
     The expected result should have the added layers take the original index of the split layers.
-    """
+    """  # noqa: D205
     expected = pd.DataFrame(
         {
             "point_id": ["BH-1", "BH-1", "BH-1", "BH-2", "BH-2", "BH-2"],


### PR DESCRIPTION
## Description
Improve consistency of terms and cross-references accross the private and public API, and test documentations.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.