### PR TITLE
docs(api-reference): add subaccessors section to subaccessor template

### DIFF
--- a/docs/_templates/autosummary/accessor.rst
+++ b/docs/_templates/autosummary/accessor.rst
@@ -4,18 +4,16 @@
 
 .. autoaccessor:: {{ (module.split('.')[1:] + [objname]) | join('.') }}
 
-{% block members -%}
-{% if members -%}
+{%- block members %}
+{%- if members %}
+
 {{ _('Subaccessors') | escape | underline('-') }}
 
 .. autosummary::
    :toctree:
    :template: autosummary/accessor_subaccessor.rst
-{% for item in members %}
-{#- This is needed since to filter out private members -#}
-{% if item[0] != "_" %}
+{% for item in members if item[0] != "_" %}
    {{ name }}.{{ item }}
-{%- endif %}
 {%- endfor %}
 {%- endif %}
 {%- endblock %}

--- a/docs/_templates/autosummary/accessor_subaccessor.rst
+++ b/docs/_templates/autosummary/accessor_subaccessor.rst
@@ -4,24 +4,41 @@
 
 .. autoaccessorcallable:: {{ (module.split('.')[1:] + [objname]) | join('.') }}
 
-{% block methods -%}
-{% if methods -%}
+{%- block members %}
+{%- for item in members if item not in methods and item not in attributes and item[0] != "_" %}
+{%- if loop.length > 0 %}
+{%- if loop.index == 1 %}
+
+{{ _('Subaccessors') | escape | underline('-') }}
+
+.. autosummary::
+   :toctree:
+   :template: autosummary/accessor_subaccessor.rst
+{% endif %} 
+   {{ name }}.{{ item }}
+{%- endif %}
+{%- endfor %}
+{%- endblock %}
+
+{%- block methods %}
+{%- for item in methods if methods and item[0] != "_" %}
+{%- if loop.length > 0 %}
+{%- if loop.index == 1 %}
+
 {{ _('Methods') | escape | underline('-') }}
 
 .. autosummary::
    :toctree:
    :template: autosummary/accessor_method.rst
-{% for item in methods %}
-{#- This is needed to filter out private methods -#}
-{% if item[0] != "_" %}
+{% endif %}
    {{ name }}.{{ item }}
 {%- endif %}
 {%- endfor %}
-{%- endif %}
 {%- endblock %}
 
-{% block attributes -%}
-{% if attributes -%}
+{%- block attributes %}
+{%- if attributes %}
+
 {{ _('Attributes') | escape | underline('-') }}
 
 .. autosummary::


### PR DESCRIPTION
## Description
Adds subaccessors section to subaccessor template and removes extra leftover whitespaces in templates.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.