### PR TITLE
feat(spt): add ability to get the total penetration of each layer

### DIFF
--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -12,3 +12,34 @@ First, we import the necessary libraries,
 
     import pandas as pd
     import geotech_pandas
+
+Next, we create a :external:class:`~pandas.DataFrame` with the following data,
+
+.. ipython:: python
+
+    df = pd.DataFrame(
+        {
+            "point_id": ["BH-1", "BH-1", "BH-1", "BH-1", "BH-1", "BH-1"],
+            "bottom": [1.5, 3.0, 4.5, 6.0, 7.5, 9.0],
+            "sample_type": ["spt", "spt", "spt", "spt", "spt", "spt"],
+            "sample_number": [1, 2, 3, 4, 5, 6],
+            "blows_1": [10, 14, 18, 25, 33, 40],
+            "blows_2": [12, 13, 20, 20, 35, 45],
+            "blows_3": [15, 13, 23, 27, 37, 50],
+            "pen_1": [150, 150, 150, 150, 150, 150],
+            "pen_2": [150, 150, 150, 150, 150, 150],
+            "pen_3": [150, 150, 150, 150, 150, 50],
+        }
+    )
+    df
+
+Getting the total penetration
+-----------------------------
+One of the methods under :class:`~pandas.DataFrame.geotech.in_situ.spt` is the ability to get the
+total penetration of each SPT interval. The
+:meth:`~pandas.DataFrame.geotech.in_situ.spt.get_total_pen` method returns a
+:external:class:`~pandas.Series` with the sum of the penetration per inteval in each sample/layer.
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_total_pen()

--- a/src/geotech_pandas/in_situ/spt.py
+++ b/src/geotech_pandas/in_situ/spt.py
@@ -1,7 +1,31 @@
 """Subaccessor that contains SPT-related methods."""
 
+import pandas as pd
+
 from geotech_pandas.base import GeotechPandasBase
 
 
 class SPTDataFrameAccessor(GeotechPandasBase):
     """Subaccessor that contains methods related to the Standard Penetration Test (SPT)."""
+
+    def __init__(self, accessor) -> None:
+        super().__init__(accessor)
+        self._validate_columns(
+            [
+                "sample_type",
+                "sample_number",
+                "blows_1",
+                "blows_2",
+                "blows_3",
+                "pen_1",
+                "pen_2",
+                "pen_3",
+            ]
+        )
+
+    def get_total_pen(self) -> pd.Series:
+        """Return the total penetration of each interval."""
+        return pd.Series(
+            self._obj[["pen_1", "pen_2", "pen_3"]].sum(axis=1, min_count=1),
+            name="total_pen",
+        )

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -7,7 +7,6 @@ import pytest
 import geotech_pandas  # noqa: F401
 from geotech_pandas.accessor import GeotechDataFrameAccessor
 from geotech_pandas.in_situ.in_situ import InSituDataFrameAccessor
-from geotech_pandas.in_situ.spt import SPTDataFrameAccessor
 from geotech_pandas.layer import LayerDataFrameAccessor
 from geotech_pandas.point import PointDataFrameAccessor
 
@@ -28,7 +27,6 @@ def df():
     [
         (["geotech"], GeotechDataFrameAccessor),
         (["geotech", "in_situ"], InSituDataFrameAccessor),
-        (["geotech", "in_situ", "spt"], SPTDataFrameAccessor),
         (["geotech", "layer"], LayerDataFrameAccessor),
         (["geotech", "point"], PointDataFrameAccessor),
     ],

--- a/tests/test_in_situ/__init__.py
+++ b/tests/test_in_situ/__init__.py
@@ -1,0 +1,1 @@
+"""in-situ submodule test suite."""

--- a/tests/test_in_situ/test_spt.py
+++ b/tests/test_in_situ/test_spt.py
@@ -1,0 +1,50 @@
+"""Test ``spt`` subaccessor methods."""
+import pandas as pd
+import pandas._testing as tm
+import pytest
+
+from geotech_pandas.in_situ import SPTDataFrameAccessor
+
+
+@pytest.fixture()
+def df():
+    """Return a dataframe with various data configurations for testing.
+
+    This dataframe is set up like a parametrized fixture where each point would expect a different
+    outcome for each method in the spt subaccessor. The following are brief descriptions of each
+    point:
+    - normal: normal spt result
+    - hw: hammer weight spt result
+    - uds: uds sample, no spt processing should be done
+    - ref_1: refusal with the partial penetration on the last interval
+    - ref_2: refusal with the partial penetration on the second interval
+    - ref_3: refusal with the partial penetration on the first interval
+    """
+    return pd.DataFrame(
+        {
+            "point_id": ["normal", "hw", "uds", "ref_1", "ref_2", "ref_3"],
+            "bottom": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            "sample_type": ["spt", "spt", "uds", "spt", "spt", "spt"],
+            "sample_number": [1, 1, 1, 1, 1, 1],
+            "blows_1": [23, 0, None, 45, 43, 50],
+            "blows_2": [25, 0, None, 47, 50, None],
+            "blows_3": [24, 0, None, 50, None, None],
+            "pen_1": [150, 150, None, 150, 150, 50],
+            "pen_2": [150, 150, None, 150, 150, None],
+            "pen_3": [150, 150, None, 100, None, None],
+            "total_pen": [450, 450, None, 400, 300, 50],
+        }
+    )
+
+
+def test_accessor():
+    """Test if accessor is registered correctly."""
+    isinstance(pd.DataFrame.geotech.in_situ.spt, SPTDataFrameAccessor)
+
+
+def test_get_total_pen(df):
+    """Test if the correct calculation is returned."""
+    tm.assert_series_equal(
+        df.geotech.in_situ.spt.get_total_pen(),
+        df["total_pen"],
+    )


### PR DESCRIPTION
## Description
Adds ability to get the total penetration of each sample layer by summing up the peneteration per inteval.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.