### PR TITLE
feat(spt): add ability to get the seating drive of each layer

### DIFF
--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -19,19 +19,33 @@ Next, we create a :external:class:`~pandas.DataFrame` with the following data,
 
     df = pd.DataFrame(
         {
-            "point_id": ["BH-1", "BH-1", "BH-1", "BH-1", "BH-1", "BH-1"],
-            "bottom": [1.5, 3.0, 4.5, 6.0, 7.5, 9.0],
-            "sample_type": ["spt", "spt", "spt", "spt", "spt", "spt"],
-            "sample_number": [1, 2, 3, 4, 5, 6],
-            "blows_1": [10, 14, 18, 25, 33, 40],
-            "blows_2": [12, 13, 20, 20, 35, 45],
-            "blows_3": [15, 13, 23, 27, 37, 50],
-            "pen_1": [150, 150, 150, 150, 150, 150],
-            "pen_2": [150, 150, 150, 150, 150, 150],
-            "pen_3": [150, 150, 150, 150, 150, 50],
+            "point_id": ["BH-1", "BH-1", "BH-1", "BH-1", "BH-1", "BH-1", "BH-1"],
+            "bottom": [1.5, 3.0, 4.5, 6.0, 7.5, 9.0, 10.0],
+            "sample_type": ["spt", "spt", "spt", "spt", "spt", "spt", "spt"],
+            "sample_number": [1, 2, 3, 4, 5, 6, 7],
+            "blows_1": [10, 14, 18, 25, 33, 40, 50],
+            "blows_2": [12, 13, 20, 20, 35, 45, None],
+            "blows_3": [15, 13, 23, 27, 37, 50, None],
+            "pen_1": [150, 150, 150, 150, 150, 150, 10],
+            "pen_2": [150, 150, 150, 150, 150, 150, None],
+            "pen_3": [150, 150, 150, 150, 150, 50, None],
         }
     )
+    df = df.convert_dtypes()
     df
+
+.. note::
+
+    Notice that the ``df`` is reassigned with the result of
+    :external:meth:`~pandas.DataFrame.convert_dtypes` method. This method converts the columns of
+    ``df`` to the best possible dtypes that support :external:attr:`~pandas.NA` to consistently
+    represent missing data.
+
+    Use the :external:attr:`~pandas.DataFrame.dtypes` property to show the current dtypes of ``df``,
+
+    .. ipython:: python
+
+        df.dtypes
 
 Getting the total penetration
 -----------------------------
@@ -43,3 +57,20 @@ total penetration of each SPT interval. The
 .. ipython:: python
 
     df.geotech.in_situ.spt.get_total_pen()
+
+Getting the seating drive
+-------------------------
+It is also possible to get the seating drive, which is, by definition, the number of blows required
+to penetrate the first 150 mm interval. The
+:meth:`~pandas.DataFrame.geotech.in_situ.spt.get_seating_drive` method returns such a result for
+each sample/layer.
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_seating_drive()
+
+.. note::
+
+    Notice that the last value is :external:attr:`~pandas.NA`, this is because the first interval
+    didn't reach the full 150 mm requirement. Such cases are usually considered as invalid tests or
+    hint to the start of a hard layer of soil or rock.

--- a/src/geotech_pandas/in_situ/spt.py
+++ b/src/geotech_pandas/in_situ/spt.py
@@ -29,3 +29,15 @@ class SPTDataFrameAccessor(GeotechPandasBase):
             self._obj[["pen_1", "pen_2", "pen_3"]].sum(axis=1, min_count=1),
             name="total_pen",
         )
+
+    def get_seating_drive(self) -> pd.Series:
+        """Return the number of blows in the first 150 mm interval for each sample.
+
+        Notes
+        -----
+        The seating drive is defined as the first 150 mm interval driven by the sampler, therefore,
+        only the number of blows of samples with ``pen_1`` equal to 150 mm are taken.
+        """
+        seating_drive = self._obj["blows_1"].convert_dtypes()
+        seating_drive.loc[self._obj["pen_1"].ne(150)] = pd.NA
+        return pd.Series(seating_drive, name="seating_drive")

--- a/tests/test_in_situ/test_spt.py
+++ b/tests/test_in_situ/test_spt.py
@@ -33,8 +33,9 @@ def df():
             "pen_2": [150, 150, None, 150, 150, None],
             "pen_3": [150, 150, None, 100, None, None],
             "total_pen": [450, 450, None, 400, 300, 50],
-        }
-    )
+            "seating_drive": [23, 0, None, 45, 43, None],
+        },
+    ).convert_dtypes()
 
 
 def test_accessor():
@@ -47,4 +48,12 @@ def test_get_total_pen(df):
     tm.assert_series_equal(
         df.geotech.in_situ.spt.get_total_pen(),
         df["total_pen"],
+    )
+
+
+def test_get_seating_blows(df):
+    """Test if the correct calculation is returned."""
+    tm.assert_series_equal(
+        df.geotech.in_situ.spt.get_seating_drive(),
+        df["seating_drive"],
     )


### PR DESCRIPTION
## Description
Adds ability to get the seating drive of each sample layer by returning the number of blows in the first interval where the penetration is 150 mm.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.