### PR TITLE
feat(spt): add ability to get the main drive of each layer

### DIFF
--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -74,3 +74,19 @@ each sample/layer.
     Notice that the last value is :external:attr:`~pandas.NA`, this is because the first interval
     didn't reach the full 150 mm requirement. Such cases are usually considered as invalid tests or
     hint to the start of a hard layer of soil or rock.
+
+Getting the main drive
+----------------------
+The main drive, which is the total number of blows in the second and third 150 mm interval, can also
+be returned by the :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_main_drive` method for each
+sample/layer.
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_main_drive()
+
+.. note::
+
+    This method simply sums up the second and third interval regardless if the intervals are
+    completely penetrated or not. Due to this, the main drive may not always correspond to the
+    reported N-value.

--- a/src/geotech_pandas/in_situ/spt.py
+++ b/src/geotech_pandas/in_situ/spt.py
@@ -52,3 +52,19 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         seating_drive = self._obj["blows_1"].convert_dtypes()
         seating_drive.loc[self._obj["pen_1"].ne(150)] = pd.NA
         return pd.Series(seating_drive, name="seating_drive")
+
+    def get_main_drive(self) -> pd.Series:
+        """Return the total blows in the second and third 150 mm interval for each sample.
+
+        The sum is still returned regardless of the completeness of each interval. Due to this, the
+        results may not correspond to the reported N-value.
+
+        Returns
+        -------
+        :external:class:`~pandas.Series`
+            Series with main drive values.
+        """
+        return pd.Series(
+            self._obj[["blows_2", "blows_3"]].sum(axis=1, min_count=1),
+            name="main_drive",
+        )

--- a/tests/test_in_situ/test_spt.py
+++ b/tests/test_in_situ/test_spt.py
@@ -34,6 +34,7 @@ def df():
             "pen_3": [150, 150, None, 100, None, None],
             "total_pen": [450, 450, None, 400, 300, 50],
             "seating_drive": [23, 0, None, 45, 43, None],
+            "main_drive": [49, 0, None, 97, 50, None],
         },
     ).convert_dtypes()
 
@@ -56,4 +57,12 @@ def test_get_seating_blows(df):
     tm.assert_series_equal(
         df.geotech.in_situ.spt.get_seating_drive(),
         df["seating_drive"],
+    )
+
+
+def test_get_main_drive(df):
+    """Test if the correct calculation is returnd."""
+    tm.assert_series_equal(
+        df.geotech.in_situ.spt.get_main_drive(),
+        df["main_drive"],
     )


### PR DESCRIPTION
## Description
Adds ability to get the main drive of each sample layer by returning the total number of blows in the second and third intervals.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.