### PR TITLE
feat(spt): add ability to get the N-value of each layer

### DIFF
--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -90,3 +90,55 @@ sample/layer.
     This method simply sums up the second and third interval regardless if the intervals are
     completely penetrated or not. Due to this, the main drive may not always correspond to the
     reported N-value.
+
+Getting the N-value
+-------------------
+The SPT is mainly done to calculate the N-value. This can easily be calculated using the
+:meth:`~pandas.DataFrame.geotech.in_situ.spt.get_n_value` method for each sample/layer.
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_n_value()
+
+As you can see, the N-value for the last two samples are set to 50, but why? This is because the
+total penetration in these samples are less than 450 mm. This means that these samples satisfy the
+refusal criteria and are assumed to have an N-value of 50.
+
+Setting the assumed refusal N-value
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The refusal N-value can easily be changed by setting the ``refusal`` parameter like so,
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_n_value(refusal=100)
+
+You can also set it to :external:attr:`~pandas.NA` if you don't want to assume a refusal N-value,
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_n_value(refusal=pd.NA)
+
+Limiting the N-values
+^^^^^^^^^^^^^^^^^^^^^
+The ``limit`` parameter is also available if you wish to limit the non-refusal N-values to the
+refusal N-value. To limit the N-values, just set the ``limit`` parameter to ``True``,
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_n_value(limit=True)
+
+As you can see, the N-value in index ``4`` was limited from 72 to 50.
+
+.. warning::
+
+    Setting ``limit`` to ``True`` while also setting ``refusal`` to :external:attr:`~pandas.NA` will
+    have a similar output to ``Out[12]`` above. That is to say, the refusal N-value will change as
+    expected, however, since it is essentially nothing, nothing will get limited as well.
+
+    .. ipython:: python
+        :okwarning:
+
+        df.geotech.in_situ.spt.get_n_value(refusal=pd.NA, limit=True)
+    
+    :mod:`geotech-pandas` will warn you if it detects you using such settings, so don't worry if you
+    forget about this warning.

--- a/tests/test_in_situ/test_spt.py
+++ b/tests/test_in_situ/test_spt.py
@@ -21,22 +21,25 @@ def df() -> pd.DataFrame:
     - ref_1: refusal with the partial penetration on the last interval
     - ref_2: refusal with the partial penetration on the second interval
     - ref_3: refusal with the partial penetration on the first interval
+    - high: high N-value to test if `get_n_value(limit=True)` works as expected
     """
     return pd.DataFrame(
         {
-            "point_id": ["normal", "hw", "uds", "ref_1", "ref_2", "ref_3"],
-            "bottom": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-            "sample_type": ["spt", "spt", "uds", "spt", "spt", "spt"],
-            "sample_number": [1, 1, 1, 1, 1, 1],
-            "blows_1": [23, 0, None, 45, 43, 50],
-            "blows_2": [25, 0, None, 47, 50, None],
-            "blows_3": [24, 0, None, 50, None, None],
-            "pen_1": [150, 150, None, 150, 150, 50],
-            "pen_2": [150, 150, None, 150, 150, None],
-            "pen_3": [150, 150, None, 100, None, None],
-            "total_pen": [450, 450, None, 400, 300, 50],
-            "seating_drive": [23, 0, None, 45, 43, None],
-            "main_drive": [49, 0, None, 97, 50, None],
+            "point_id": ["normal", "hw", "uds", "ref_1", "ref_2", "ref_3", "high"],
+            "bottom": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            "sample_type": ["spt", "spt", "uds", "spt", "spt", "spt", "spt"],
+            "sample_number": [1, 1, 1, 1, 1, 1, 1],
+            "blows_1": [23, 0, None, 45, 43, 50, 49],
+            "blows_2": [25, 0, None, 47, 50, None, 47],
+            "blows_3": [24, 0, None, 50, None, None, 49],
+            "pen_1": [150, 150, None, 150, 150, 50, 150],
+            "pen_2": [150, 150, None, 150, 150, None, 150],
+            "pen_3": [150, 150, None, 100, None, None, 150],
+            "total_pen": [450, 450, None, 400, 300, 50, 450],
+            "seating_drive": [23, 0, None, 45, 43, None, 49],
+            "main_drive": [49, 0, None, 97, 50, None, 96],
+            "n_value_1": [49, 0, None, 50, 50, 50, 96],
+            "n_value_2": [49, 0, None, 50, 50, 50, 50],
         },
     ).convert_dtypes()
 
@@ -47,13 +50,38 @@ def test_accessor():
 
 
 @pytest.mark.parametrize(
-    ("method", "column"),
+    ("method", "column", "rename", "kwargs"),
     [
-        ("geotech.in_situ.spt.get_total_pen", "total_pen"),
-        ("geotech.in_situ.spt.get_seating_drive", "seating_drive"),
-        ("geotech.in_situ.spt.get_main_drive", "main_drive"),
+        ("geotech.in_situ.spt.get_total_pen", "total_pen", None, None),
+        ("geotech.in_situ.spt.get_seating_drive", "seating_drive", None, None),
+        ("geotech.in_situ.spt.get_main_drive", "main_drive", None, None),
+        ("geotech.in_situ.spt.get_n_value", "n_value_1", "n_value", None),
+        ("geotech.in_situ.spt.get_n_value", "n_value_2", "n_value", {"limit": True}),
     ],
 )
-def test_spt_methods(df, method, column):
-    """Test if the results of the method are equal with the contents of the column."""
-    tm.assert_series_equal(reduce(getattr, method.split("."), df)(), df[column])
+def test_spt_methods(df, method, column, rename, kwargs):
+    """Test if the results of the `method` are equal with the contents of the `column`.
+
+    Parameters
+    ----------
+    df: :external:class:`~pandas.DataFrame`
+        DataFrame fixture.
+    method: str
+        Full method signature to call from `df`.
+    column: str
+        Column to extract from `df` for comparison.
+    rename: str, optional
+        Name to rename `column` with after extraction. If `None`, no renaming is done.
+    kwargs: dict, optional
+        Keyword argument dictionary to pass to `method`. If `None`, the method is called as is.
+    """
+    result = reduce(getattr, method.split("."), df)
+    result = result() if kwargs is None else result(**kwargs)
+    expected = df[column] if rename is None else df[column].rename(rename)
+    tm.assert_series_equal(result, expected)
+
+
+def test_get_n_value_warning(df):
+    """Test if a warning is triggered when `refusal` is set to `pandas.NA` and `limit` is `True."""
+    with pytest.warns(SyntaxWarning):
+        df.geotech.in_situ.spt.get_n_value(refusal=pd.NA, limit=True)


### PR DESCRIPTION
## Description
Adds ability to get the N-value of each sample layer by returning the main drive with consideration of the refusal criteria.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.