### PR TITLE
feat(spt): add ability to get the main penetration of each layer

### DIFF
--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -47,6 +47,16 @@ Next, we create a :external:class:`~pandas.DataFrame` with the following data,
 
         df.dtypes
 
+Getting the main penetration
+----------------------------
+The :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_main_pen` method returns a
+:external:class:`~pandas.Series` with the sum of the penetration in the second and third 150 mm
+interval for each sample/layer.
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_main_pen()
+
 Getting the total penetration
 -----------------------------
 One of the methods under :class:`~pandas.DataFrame.geotech.in_situ.spt` is the ability to get the
@@ -141,7 +151,7 @@ As you can see, the N-value in index ``4`` was limited from 72 to 50.
 .. warning::
 
     Setting ``limit`` to ``True`` while also setting ``refusal`` to :external:attr:`~pandas.NA` will
-    have a similar output to ``Out[13]`` above. That is to say, the refusal N-value will change as
+    have a similar output to ``Out[14]`` above. That is to say, the refusal N-value will change as
     expected, however, since it is essentially nothing, nothing will get limited as well.
 
     .. ipython:: python

--- a/src/geotech_pandas/in_situ/spt.py
+++ b/src/geotech_pandas/in_situ/spt.py
@@ -27,6 +27,19 @@ class SPTDataFrameAccessor(GeotechPandasBase):
             ]
         )
 
+    def get_main_pen(self) -> pd.Series:
+        """Return the total penetration in the second and third 150 mm interval for each sample.
+
+        Returns
+        -------
+        :external:class:`~pandas.Series`
+            Series with main penetration values.
+        """
+        return pd.Series(
+            self._obj[["pen_2", "pen_3"]].sum(axis=1, min_count=1),
+            name="main_pen",
+        )
+
     def get_total_pen(self) -> pd.Series:
         """Return the total penetration of each interval.
 

--- a/tests/test_in_situ/test_spt.py
+++ b/tests/test_in_situ/test_spt.py
@@ -35,6 +35,7 @@ def df() -> pd.DataFrame:
             "pen_1": [150, 150, None, 150, 150, 50, 150],
             "pen_2": [150, 150, None, 150, 150, None, 150],
             "pen_3": [150, 150, None, 100, None, None, 150],
+            "main_pen": [300, 300, None, 250, 150, None, 300],
             "total_pen": [450, 450, None, 400, 300, 50, 450],
             "seating_drive": [23, 0, None, 45, 43, None, 49],
             "main_drive": [49, 0, None, 97, 50, None, 96],
@@ -53,6 +54,7 @@ def test_accessor():
 @pytest.mark.parametrize(
     ("method", "column", "rename", "kwargs"),
     [
+        ("geotech.in_situ.spt.get_main_pen", "main_pen", None, None),
         ("geotech.in_situ.spt.get_total_pen", "total_pen", None, None),
         ("geotech.in_situ.spt.get_seating_drive", "seating_drive", None, None),
         ("geotech.in_situ.spt.get_main_drive", "main_drive", None, None),


### PR DESCRIPTION
## Description
Adds ability to get the main penetration of each sample layer by returning the total penetration in the second and third intervals.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.