### PR TITLE
feat(spt): add ability to get the seating penetration of each layer

### DIFF
--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -47,6 +47,17 @@ Next, we create a :external:class:`~pandas.DataFrame` with the following data,
 
         df.dtypes
 
+Getting the seating penetration
+-------------------------------
+The :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_seating_pen` method returns a
+:external:class:`~pandas.Series` of penetration measurements in the first interval, where the
+measurements are exactly 150 mm. Measurements that do not meet the requirements are
+masked with :external:attr:`~pandas.NA`.
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.get_seating_pen()
+
 Getting the main penetration
 ----------------------------
 The :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_main_pen` method returns a
@@ -151,7 +162,7 @@ As you can see, the N-value in index ``4`` was limited from 72 to 50.
 .. warning::
 
     Setting ``limit`` to ``True`` while also setting ``refusal`` to :external:attr:`~pandas.NA` will
-    have a similar output to ``Out[14]`` above. That is to say, the refusal N-value will change as
+    have a similar output to ``Out[15]`` above. That is to say, the refusal N-value will change as
     expected, however, since it is essentially nothing, nothing will get limited as well.
 
     .. ipython:: python

--- a/tests/test_in_situ/test_spt.py
+++ b/tests/test_in_situ/test_spt.py
@@ -35,6 +35,7 @@ def df() -> pd.DataFrame:
             "pen_1": [150, 150, None, 150, 150, 50, 150],
             "pen_2": [150, 150, None, 150, 150, None, 150],
             "pen_3": [150, 150, None, 100, None, None, 150],
+            "seating_pen": [150, 150, None, 150, 150, None, 150],
             "main_pen": [300, 300, None, 250, 150, None, 300],
             "total_pen": [450, 450, None, 400, 300, 50, 450],
             "seating_drive": [23, 0, None, 45, 43, None, 49],
@@ -54,6 +55,7 @@ def test_accessor():
 @pytest.mark.parametrize(
     ("method", "column", "rename", "kwargs"),
     [
+        ("geotech.in_situ.spt.get_seating_pen", "seating_pen", None, None),
         ("geotech.in_situ.spt.get_main_pen", "main_pen", None, None),
         ("geotech.in_situ.spt.get_total_pen", "total_pen", None, None),
         ("geotech.in_situ.spt.get_seating_drive", "seating_drive", None, None),


### PR DESCRIPTION
## Description
Adds ability to get the seating penetration of each sample layer by returning the penetration measurements in the first interval, where the measurements are exactly 150 mm.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.