### PR TITLE
docs(spt): replace "interval" with "increment"

### DIFF
--- a/docs/user-guide/in-situ.rst
+++ b/docs/user-guide/in-situ.rst
@@ -4,7 +4,7 @@ In-Situ Subaccessor
 In :mod:`geotech-pandas`, the :class:`~pandas.DataFrame.geotech.in_situ` subaccessor is simply a
 namespace that contains other subaccessors with methods that deal with in-situ tests. In general,
 the methods in these subaccessors only handle raw in-situ test data. For example, a method that
-reads the blow counts of each interval in a standard penetration test and returns the equivalent
+reads the blow counts of each increment in a standard penetration test and returns the equivalent
 N-value. These subaccessors are further discussed in the following sections.
 
 .. toctree::

--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -50,7 +50,7 @@ Next, we create a :external:class:`~pandas.DataFrame` with the following data,
 Getting the seating penetration
 -------------------------------
 The :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_seating_pen` method returns a
-:external:class:`~pandas.Series` of penetration measurements in the first interval, where the
+:external:class:`~pandas.Series` of penetration measurements in the first increment, where the
 measurements are exactly 150 mm. Measurements that do not meet the requirements are
 masked with :external:attr:`~pandas.NA`.
 
@@ -62,7 +62,7 @@ Getting the main penetration
 ----------------------------
 The :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_main_pen` method returns a
 :external:class:`~pandas.Series` with the sum of the penetration in the second and third 150 mm
-interval for each sample/layer.
+increment for each sample/layer.
 
 .. ipython:: python
 
@@ -71,7 +71,7 @@ interval for each sample/layer.
 Getting the total penetration
 -----------------------------
 One of the methods under :class:`~pandas.DataFrame.geotech.in_situ.spt` is the ability to get the
-total penetration of each SPT interval. The
+total penetration of each SPT increment. The
 :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_total_pen` method returns a
 :external:class:`~pandas.Series` with the sum of the penetration per inteval in each sample/layer.
 
@@ -82,7 +82,7 @@ total penetration of each SPT interval. The
 Getting the seating drive
 -------------------------
 It is also possible to get the seating drive, which is, by definition, the number of blows required
-to penetrate the first 150 mm interval. The
+to penetrate the first 150 mm increment. The
 :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_seating_drive` method returns such a result for
 each sample/layer.
 
@@ -92,14 +92,14 @@ each sample/layer.
 
 .. note::
 
-    Notice that the last value is :external:attr:`~pandas.NA`, this is because the first interval
+    Notice that the last value is :external:attr:`~pandas.NA`, this is because the first increment
     didn't reach the full 150 mm requirement. Such cases are usually considered as invalid tests or
     hint to the start of a hard layer of soil or rock.
 
 Getting the main drive
 ----------------------
-The main drive, which is the total number of blows in the second and third 150 mm interval, can also
-be returned by the :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_main_drive` method for each
+The main drive, which is the total number of blows in the second and third 150 mm increment, can
+also be returned by the :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_main_drive` method for each
 sample/layer.
 
 .. ipython:: python
@@ -108,13 +108,13 @@ sample/layer.
 
 .. note::
 
-    This method simply sums up the second and third interval regardless if the intervals are
+    This method simply sums up the second and third increment regardless if the increments are
     completely penetrated or not. Due to this, the main drive may not always correspond to the
     reported N-value.
 
 Getting the total drive
 -----------------------
-It is also possible to calculate the total number of blows in all three 150 mm intervals for each
+It is also possible to calculate the total number of blows in all three 150 mm increments for each
 sample/layer through the :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_total_drive` method.
 
 .. ipython:: python

--- a/src/geotech_pandas/in_situ/spt.py
+++ b/src/geotech_pandas/in_situ/spt.py
@@ -29,7 +29,7 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         )
 
     def get_seating_pen(self) -> pd.Series:
-        """Return the seating penetration from the first interval of each sample.
+        """Return the seating penetration from the first increment of each sample.
 
         Only full penetrations of 150 mm are returned, where partial penetrations are masked with
         `NA`.
@@ -44,7 +44,7 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         return pd.Series(seating_pen, name="seating_pen")
 
     def get_main_pen(self) -> pd.Series:
-        """Return the total penetration in the second and third 150 mm interval for each sample.
+        """Return the total penetration in the second and third 150 mm increment for each sample.
 
         Returns
         -------
@@ -57,7 +57,7 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         )
 
     def get_total_pen(self) -> pd.Series:
-        """Return the total penetration of each interval.
+        """Return the total penetration of each increment.
 
         Returns
         -------
@@ -70,7 +70,7 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         )
 
     def get_seating_drive(self) -> pd.Series:
-        """Return the number of blows in the first 150 mm interval for each sample.
+        """Return the number of blows in the first 150 mm increment for each sample.
 
         Returns
         -------
@@ -79,7 +79,7 @@ class SPTDataFrameAccessor(GeotechPandasBase):
 
         Notes
         -----
-        The seating drive is defined as the first 150 mm interval driven by the sampler, therefore,
+        The seating drive is defined as the first 150 mm increment driven by the sampler, therefore,
         only the number of blows of samples with ``pen_1`` equal to 150 mm are taken.
         """
         seating_drive = self._obj["blows_1"].convert_dtypes()
@@ -87,9 +87,9 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         return pd.Series(seating_drive, name="seating_drive")
 
     def get_main_drive(self) -> pd.Series:
-        """Return the total blows in the second and third 150 mm interval for each sample.
+        """Return the total blows in the second and third 150 mm increment for each sample.
 
-        The sum is still returned regardless of the completeness of each interval. Due to this, the
+        The sum is still returned regardless of the completeness of each increment. Due to this, the
         results may not correspond to the reported N-value.
 
         Returns
@@ -103,9 +103,9 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         )
 
     def get_total_drive(self) -> pd.Series:
-        """Return the sum of the number of blows in all three 150 mm intervals of each sample.
+        """Return the sum of the number of blows in all three 150 mm increments of each sample.
 
-        The sum is still returned regardless of the completeness of each interval.
+        The sum is still returned regardless of the completeness of each increment.
 
         Returns
         -------

--- a/tests/test_in_situ/test_spt.py
+++ b/tests/test_in_situ/test_spt.py
@@ -18,9 +18,9 @@ def df() -> pd.DataFrame:
     - normal: normal spt result
     - hw: hammer weight spt result
     - uds: uds sample, no spt processing should be done
-    - ref_1: refusal with the partial penetration on the last interval
-    - ref_2: refusal with the partial penetration on the second interval
-    - ref_3: refusal with the partial penetration on the first interval
+    - ref_1: refusal with the partial penetration on the last increment
+    - ref_2: refusal with the partial penetration on the second increment
+    - ref_3: refusal with the partial penetration on the first increment
     - high: high N-value to test if `get_n_value(limit=True)` works as expected
     """
     return pd.DataFrame(


### PR DESCRIPTION
## Description
Replaces the use of "interval" with "increment" in the docs.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.