### PR TITLE
feat(spt): add ability to check if any sample is a refusal

### DIFF
--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -24,7 +24,7 @@ Next, we create a :external:class:`~pandas.DataFrame` with the following data,
             "sample_type": ["spt", "spt", "spt", "spt", "spt", "spt", "spt"],
             "sample_number": [1, 2, 3, 4, 5, 6, 7],
             "blows_1": [10, 14, 18, 25, 33, 40, 50],
-            "blows_2": [12, 13, 20, 20, 35, 45, None],
+            "blows_2": [12, 13, 20, 29, 35, 45, None],
             "blows_3": [15, 13, 23, 27, 37, 50, None],
             "pen_1": [150, 150, 150, 150, 150, 150, 10],
             "pen_2": [150, 150, 150, 150, 150, 150, None],
@@ -121,6 +121,23 @@ sample/layer through the :meth:`~pandas.DataFrame.geotech.in_situ.spt.get_total_
 
     df.geotech.in_situ.spt.get_total_drive()
 
+Checking for refusal samples
+----------------------------
+It is possible to check for which samples refused penetration through
+:meth:`~pandas.DataFrame.geotech.in_situ.spt.is_refusal`. This method will return ``True`` for any
+sample that may be considered a refusal.
+
+A sample is considered a refusal when any of the following is true:
+
+ - a total of 50 blows or more have been applied during any of the three 150 mm increments;
+ - a total of 100 blows or more have been applied; and
+ - partial penetration, which signifies that the sampler can no longer penetrate through the
+   strata, is present in any of the increments.
+
+.. ipython:: python
+
+    df.geotech.in_situ.spt.is_refusal()
+
 Getting the N-value
 -------------------
 The SPT is mainly done to calculate the N-value. This can easily be calculated using the
@@ -130,13 +147,13 @@ The SPT is mainly done to calculate the N-value. This can easily be calculated u
 
     df.geotech.in_situ.spt.get_n_value()
 
-As you can see, the N-value for the last two samples are set to 50, but why? This is because the
-total penetration in these samples are less than 450 mm. This means that these samples satisfy the
-refusal criteria and are assumed to have an N-value of 50.
+As you can see, the N-values for the last three samples are set to 50, but why? This is because
+these samples are refusals and are assumed to have an N-value of 50; however, this behavior can be
+customized.
 
 Setting the assumed refusal N-value
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The refusal N-value can easily be changed by setting the ``refusal`` parameter like so,
+The assumed refusal N-value can easily be changed by setting the ``refusal`` parameter like so,
 
 .. ipython:: python
 
@@ -157,12 +174,12 @@ refusal N-value. To limit the N-values, just set the ``limit`` parameter to ``Tr
 
     df.geotech.in_situ.spt.get_n_value(limit=True)
 
-As you can see, the N-value in index ``4`` was limited from 72 to 50.
+As you can see, the N-value at index ``3`` was limited from 56 to 50.
 
 .. warning::
 
     Setting ``limit`` to ``True`` while also setting ``refusal`` to :external:attr:`~pandas.NA` will
-    have a similar output to ``Out[15]`` above. That is to say, the refusal N-value will change as
+    have a similar output to ``Out[16]`` above. That is to say, the refusal N-value will change as
     expected, however, since it is essentially nothing, nothing will get limited as well.
 
     .. ipython:: python

--- a/tests/test_in_situ/test_spt.py
+++ b/tests/test_in_situ/test_spt.py
@@ -29,19 +29,23 @@ def df() -> pd.DataFrame:
             "bottom": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             "sample_type": ["spt", "spt", "uds", "spt", "spt", "spt", "spt"],
             "sample_number": [1, 1, 1, 1, 1, 1, 1],
-            "blows_1": [23, 0, None, 45, 43, 50, 49],
-            "blows_2": [25, 0, None, 47, 50, None, 47],
-            "blows_3": [24, 0, None, 50, None, None, 49],
+            "blows_1": [23, 0, None, 45, 43, 50, 23],
+            "blows_2": [25, 0, None, 47, 50, None, 29],
+            "blows_3": [24, 0, None, 50, None, None, 35],
             "pen_1": [150, 150, None, 150, 150, 50, 150],
             "pen_2": [150, 150, None, 150, 150, None, 150],
             "pen_3": [150, 150, None, 100, None, None, 150],
             "seating_pen": [150, 150, None, 150, 150, None, 150],
             "main_pen": [300, 300, None, 250, 150, None, 300],
             "total_pen": [450, 450, None, 400, 300, 50, 450],
-            "seating_drive": [23, 0, None, 45, 43, None, 49],
-            "main_drive": [49, 0, None, 97, 50, None, 96],
-            "total_drive": [72, 0, None, 142, 93, 50, 145],
-            "n_value_1": [49, 0, None, 50, 50, 50, 96],
+            "seating_drive": [23, 0, None, 45, 43, None, 23],
+            "main_drive": [49, 0, None, 97, 50, None, 64],
+            "total_drive": [72, 0, None, 142, 93, 50, 87],
+            "_any_blows_max_inc": [False, False, None, True, True, True, False],
+            "_any_blows_max_total": [False, False, None, True, False, False, False],
+            "_any_pen_partial": [False, False, None, True, True, True, False],
+            "is_refusal": [False, False, None, True, True, True, False],
+            "n_value_1": [49, 0, None, 50, 50, 50, 64],
             "n_value_2": [49, 0, None, 50, 50, 50, 50],
         },
     ).convert_dtypes()
@@ -61,6 +65,10 @@ def test_accessor():
         ("geotech.in_situ.spt.get_seating_drive", "seating_drive", None, None),
         ("geotech.in_situ.spt.get_main_drive", "main_drive", None, None),
         ("geotech.in_situ.spt.get_total_drive", "total_drive", None, None),
+        ("geotech.in_situ.spt._any_blows_max_inc", "_any_blows_max_inc", None, None),
+        ("geotech.in_situ.spt._any_blows_max_total", "_any_blows_max_total", None, None),
+        ("geotech.in_situ.spt._any_pen_partial", "_any_pen_partial", None, None),
+        ("geotech.in_situ.spt.is_refusal", "is_refusal", None, None),
         ("geotech.in_situ.spt.get_n_value", "n_value_1", "n_value", None),
         ("geotech.in_situ.spt.get_n_value", "n_value_2", "n_value", {"limit": True}),
     ],
@@ -91,3 +99,12 @@ def test_get_n_value_warning(df):
     """Test if a warning is triggered when `refusal` is set to `pandas.NA` and `limit` is `True."""
     with pytest.warns(SyntaxWarning):
         df.geotech.in_situ.spt.get_n_value(refusal=pd.NA, limit=True)
+
+
+def test_any_with_na_error(df):
+    """Test if a `ValueError` is raised when passing on arguments with differnt shapes."""
+    values = df[["blows_1", "blows_2", "blows_3"]]
+    max_value = 100
+    mask = df[["blows_2", "blows_3"]] >= max_value
+    with pytest.raises(ValueError, match="`values` and `mask` must have the same shape."):
+        df.geotech.in_situ.spt._any_with_na_rows(values, mask)


### PR DESCRIPTION
## Description
Adds ability to check if any sample is a refusal based on the following criteria:

 - a total of 50 blows or more have been applied during any of the three 150 mm increments;
 - a total of 100 blows or more have been applied; and
 - partial penetration, which signifies that the sampler can no longer penetrate through the
   strata, is present in any of the increments.

Also, apply the new method when getting the N-value to properly detect refusals.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.