### PR TITLE
ci(deploy): add GitHub Pages deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+# Simple workflow for building and deploying static content to GitHub Pages
+name: Deploy
+
+on:
+  # Runs when a draft, pre-release, or release is first created
+  release:
+    types:
+      - created
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Set up Node.js
+          uses: actions/setup-node@v4
+          with:
+            node-version: 18
+        - name: Install @devcontainers/cli
+          run: npm install --location=global @devcontainers/cli@0.41.0
+        - name: Start Dev Container
+          env:
+            DOCKER_BUILDKIT: 1
+          run: |
+            git config --global init.defaultBranch main
+            PYTHON_VERSION=3.9 devcontainer up --workspace-folder .
+        - name: Build docs
+          run: devcontainer exec --workspace-folder . poe docs -O "-E -a"
+        - name: Setup Pages
+          uses: actions/configure-pages@v3
+        - name: Upload artifact
+          uses: actions/upload-pages-artifact@v2
+          with:
+            path: './docs/_build/html'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,15 @@
 
 import sphinx_autosummary_accessors
 
-import geotech_pandas  # noqa: F401 registers accessor for autosummary
+try:
+    import geotech_pandas
+except ModuleNotFoundError:
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+    import geotech_pandas  # noqa: F401 registers accessor for autosummary
 
 project = "geotech-pandas"
 copyright = "2023, Fraser Dominic David"


### PR DESCRIPTION
## Description
This PR adds an action to automatically build and deploy documentation to GitHub Pages.

Also, a workaround is added in Sphinx `conf.py` to import the local module if not found. This is so it can work seamlessly with the action.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.