### PR TITLE
ci(release): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+# Simple workflow to create a version tag and release
+name: Release
+
+on:
+  push:
+    branches:
+      main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # The commit must start with "bump", otherwise skip the whole workflow
+    if: startsWith(github.event.head_commit.message, 'bump')
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      
+      - name: Install Commitizen
+        run: pip install commitizen
+      
+      # Get the current version since the bump commit has already updated the versions in the files
+      - name: Get version
+        id: version
+        run: echo "VERSION=v$(cz version --p)" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ steps.version.outputs.VERSION }}
+
+      # Get the changelog of the current version to use as the release body
+      - name: Get changelog
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: cz changelog $VERSION --dry-run --template="CHANGELOG.md.j2" > body.md
+      
+      - name: Show changelog
+        run: cat body.md
+      
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "body.md"
+          tag_name: ${{ steps.version.outputs.VERSION }}
+          # Needs PAT to ensure release creation triggers on other workflows work as expected
+          token: ${{ secrets.GH_PAT }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ tag_format = "v$version"
 update_changelog_on_bump = true
 version = "0.0.0"
 version_files = ["pyproject.toml:version", "docs/conf.py:version"]
-changelog_incremental= true
 changelog_file = "docs/changelog/changelog.rst"
 template = "docs/_templates/commitizen/changelog.rst"
 


### PR DESCRIPTION
## Description
This PR adds a release workflow that creates a tag and release upon pushing a `bump` commit.

The release workflow with this in mind should now be:

1. Create a branch.
2. Run `cz bump`. This automatically commits to the branch with message, `bump(release): v#.#.# → v#.#.#`.
3. Create a PR to merge the bump.
4. Squash and merge PR.
5. The workflow is triggered, and a release is created.
6. Once the release is created, the `publish` and `deploy` workflows will be triggered.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.

## Additional information
Due to how the workflow grabs the changelog, the `changelog_incremental` option in Commitizen is now required to be set as `false`.