### PR TITLE
ci(test): add Python 3.10 to 3.12 to workflow matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     name: Python ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Description
This PR adds Python 3.10 to 3.12 to the test workflow matrix.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.