### PR TITLE
feat(lab): add lab subaccessor

### DIFF
--- a/src/geotech_pandas/accessor.py
+++ b/src/geotech_pandas/accessor.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from geotech_pandas.base import GeotechPandasBase
 from geotech_pandas.in_situ import InSituDataFrameAccessor
+from geotech_pandas.lab import LabDataFrameAccessor
 from geotech_pandas.layer import LayerDataFrameAccessor
 from geotech_pandas.point import PointDataFrameAccessor
 from geotech_pandas.utils import SubAccessor
@@ -18,6 +19,7 @@ class GeotechDataFrameAccessor(GeotechPandasBase):
     point = SubAccessor(PointDataFrameAccessor)
     layer = SubAccessor(LayerDataFrameAccessor)
     in_situ = SubAccessor(InSituDataFrameAccessor)
+    lab = SubAccessor(LabDataFrameAccessor)
 
     def __init__(self, df: pd.DataFrame):
         self._obj = df

--- a/src/geotech_pandas/lab/__init__.py
+++ b/src/geotech_pandas/lab/__init__.py
@@ -1,0 +1,7 @@
+"""Laboratory test subaccesors."""
+
+from geotech_pandas.lab.lab import LabDataFrameAccessor
+
+__all__ = [
+    "LabDataFrameAccessor",
+]

--- a/src/geotech_pandas/lab/lab.py
+++ b/src/geotech_pandas/lab/lab.py
@@ -1,0 +1,7 @@
+"""General subaccessor for laboratory test subaccessors."""
+
+from geotech_pandas.base import GeotechPandasBase
+
+
+class LabDataFrameAccessor(GeotechPandasBase):
+    """General subaccessor that contains various subaccessors that handle laboratory test data."""

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -7,6 +7,7 @@ import pytest
 import geotech_pandas  # noqa: F401
 from geotech_pandas.accessor import GeotechDataFrameAccessor
 from geotech_pandas.in_situ.in_situ import InSituDataFrameAccessor
+from geotech_pandas.lab.lab import LabDataFrameAccessor
 from geotech_pandas.layer import LayerDataFrameAccessor
 from geotech_pandas.point import PointDataFrameAccessor
 
@@ -27,6 +28,7 @@ def df():
     [
         (["geotech"], GeotechDataFrameAccessor),
         (["geotech", "in_situ"], InSituDataFrameAccessor),
+        (["geotech", "lab"], LabDataFrameAccessor),
         (["geotech", "layer"], LayerDataFrameAccessor),
         (["geotech", "point"], PointDataFrameAccessor),
     ],


### PR DESCRIPTION
## Description
This PR adds a general subaccessor for subaccessors with methods that deal with various laboratory tests, similar to the `in_situ` subaccessor.

Closes #99

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.