### PR TITLE
docs(column-reference): add separate column reference

### DIFF
--- a/docs/api-reference/index.rst
+++ b/docs/api-reference/index.rst
@@ -3,8 +3,23 @@
 =============
 API Reference
 =============
-In geotech-pandas, scope-specific methods under various subaccessors are provided. These are
+In geotech-pandas, various subaccessors provide scope-specific methods. These methods reside in
 separate namespaces within :class:`~pandas.DataFrame.geotech`.
+
+Most methods include a *Requires* block, which lists the columns required for that specific method.
+Each listed column links to its corresponding entry in the :ref:`column-reference`.
+
+.. admonition:: **Requires:**
+   :class: important
+
+   | :term:`point_id`
+   | :term:`bottom`
+
+If the required columns are missing from the DataFrame when calling a method, an error will be
+raised. This error message will also list the missing columns. By default, :term:`point_id` and
+:term:`bottom` are the minimum required columns. However, these two columns are generally not
+defined in the *Requires* block unless the method explicitly uses them (e.g.,
+:meth:`~pandas.DataFrame.geotech.layer.get_top`).
 
 Accessor
 --------
@@ -14,111 +29,3 @@ Accessor
    :template: autosummary/accessor.rst
 
    DataFrame.geotech
-
-.. _columns:
-
-Columns
--------
-There is a heavy reliance in consistent column names and units in geotech-pandas. For now, SI units
-are assumed throughout the package. The columns used throughout the package are summarized in the
-following table:
-
-Common Columns
-^^^^^^^^^^^^^^
-.. list-table::
-   :header-rows: 1
-
-   * - Name
-     - Unit
-     - Description
-   * - ``point_id``
-     -
-     - Point ID in which a layer belongs to.
-   * - ``bottom``
-     - m
-     - Bottom depth of a layer.
-   * - ``top``
-     - m
-     - Top depth of a layer.
-   * - ``center``
-     - m
-     - Center depth of a layer.
-   * - ``thickness``
-     - m
-     - Thickness of a layer.
-   * - ``sample_type``
-     -
-     - Type of sample.
-   * - ``sample_number``
-     -
-     - Sample ID number.
-
-.. _columns_spt:
-
-SPT Columns
-^^^^^^^^^^^
-.. list-table::
-   :header-rows: 1
-
-   * - Name
-     - Unit
-     - Description
-   * - ``blows_n``
-     - blows/150mm
-     - Blow counts in the nth SPT increment.
-   * - ``pen_n``
-     - mm
-     - Length driven/penetrated by the sampler in the nth SPT increment.
-   * - ``seating_pen``
-     - mm
-     - SPT seating penetration, the penetration in the 1st increment.
-   * - ``main_pen``
-     - mm
-     - SPT main penetration, the sum of the penetration in the 2nd and 3rd increments.
-   * - ``total_pen``
-     - m
-     - SPT total penetration, the sum of the penetration in all the increments.
-   * - ``seating_drive``
-     - blows
-     - SPT seating drive, the number of blows required to drive the 1st increment.
-   * - ``main_drive``
-     - blows
-     - SPT main drive, the sum of the number of blows required to drive the 2nd and 3rd increments.
-   * - ``total_drive``
-     - blows
-     - SPT main drive, the sum of the number of blows required to drive all increments.
-   * - ``is_refusal``
-     -
-     - Whether or not SPT samples are considered refusals.
-   * - ``is_hammer_weight``
-     -
-     - Whether or not SPT samples are considered hammer weights.
-   * - ``n_value``
-     - blows/300mm
-     - SPT N-value, equivalent to the main drive if a sample is not a refusal.
-   * - ``spt_report``
-     -
-     - Simple descriptive SPT report.
-
-.. _columns_lab_index:
-
-Soil Index Columns
-^^^^^^^^^^^^^^^^^^
-.. list-table::
-   :header-rows: 1
-
-   * - Name
-     - Unit
-     - Description
-   * - ``moisture_content_mass_moist``
-     - g
-     - Mass of container and moist specimen.
-   * - ``moisture_content_mass_dry``
-     - g
-     - Mass of container and oven dry specimen.
-   * - ``moisture_content_mass_container``
-     - g
-     - Mass of container.
-   * - ``moisture_content``
-     - %
-     - Moisture content.

--- a/docs/column-reference/index.rst
+++ b/docs/column-reference/index.rst
@@ -1,0 +1,174 @@
+.. _column-reference:
+
+================
+Column Reference
+================
+geotech-pandas relies heavily on consistent column names and units. The package currently assumes
+all units are in SI (International System of Units). These columns are summarized in the following
+lists.
+
+The columns are listed in the following format:
+
+    column_name
+        | Description
+        | *unit*
+        | ``dtype``
+
+.. _general-columns:
+
+General Columns
+---------------
+.. glossary::
+
+    point_id
+        | Point ID in which a layer belongs to.
+        | *unitless*
+        | ``string``
+
+    bottom
+        | Bottom depth of a layer.
+        | *meters (m)*
+        | ``float``
+
+    top
+        | Top depth of a layer.
+        | *meters (m)*
+        | ``float``
+   
+    center
+        | Center depth of a layer.
+        | *meters (m)*
+        | ``float``
+   
+    thickness
+        | Thickness of a layer.
+        | *meters (m)*
+        | ``float``
+
+    sample_type
+        | Type of sample.
+        | *unitless*
+        | ``string``
+
+    sample_number
+        | Sample ID number.
+        | *unitless*
+        | ``int``
+
+.. _spt-columns:
+
+SPT Columns
+-----------
+.. glossary::
+
+    blows_1
+        | Blow counts in the 1st SPT increment.
+        | *blows per 150 millimeters (blows/150mm)*
+        | ``int``
+
+    blows_2
+        | Blow counts in the 2nd SPT increment.
+        | *blows per 150 millimeters (blows/150mm)*
+        | ``int``
+
+    blows_3
+        | Blow counts in the 3rd SPT increment.
+        | *blows per 150 millimeters (blows/150mm)*
+        | ``int``
+        
+    pen_1
+        | Length driven/penetrated by the sampler in the 1st SPT increment.
+        | *millimeters (mm)*
+        | ``float``
+
+    pen_2
+        | Length driven/penetrated by the sampler in the 2nd SPT increment.
+        | *millimeters (mm)*
+        | ``float``
+
+    pen_3
+        | Length driven/penetrated by the sampler in the 3rd SPT increment.
+        | *millimeters (mm)*
+        | ``float``
+
+    seating_pen
+        | SPT seating penetration, the penetration in the 1st increment.
+        | *millimeters (mm)*
+        | ``float``
+
+    main_pen
+        | SPT main penetration, the sum of the penetration in the 2nd and 3rd increments.
+        | *millimeters (mm)*
+        | ``float``
+
+    total_pen
+        | SPT total penetration, the sum of the penetration in all the increments.
+        | *millimeters (mm)*
+        | ``float``
+
+    seating_drive
+        | SPT seating drive, the number of blows required to drive the 1st increment.
+        | *blows per 150 millimeters (blows/150mm)*
+        | ``int``
+
+    main_drive
+        | SPT main drive, the sum of the number of blows required to drive the 2nd and 3rd
+          increments.
+        | *blows per 300 millimeters (blows/300mm)*
+        | ``int``
+
+    total_drive
+        | SPT total drive, the sum of the number of blows required to drive all increments.
+        | *blows per 450 millimeters (blows/450mm)*
+        | ``int``
+
+    is_refusal
+        | Whether or not SPT samples are considered refusals.
+        | *unitless*
+        | ``bool``
+
+    is_hammer_weight
+        | Whether or not SPT samples are considered hammer weights.
+        | *unitless*
+        | ``bool``
+
+    n_value
+        | SPT N-value, equivalent to the main drive if a sample is not a refusal.
+        | *blows per 300 millimeters (blows/300mm)*
+        | ``int``
+
+    spt_report
+        | Simple descriptive SPT report.
+        | *unitless*
+        | ``string``
+
+.. _soil-index-columns:
+
+Soil Index Columns
+------------------
+.. glossary::
+
+    moisture_content_mass_moist
+        | Mass of container and moist specimen.
+        | *grams (g)*
+        | ``float``
+
+    moisture_content_mass_dry
+        | Mass of container and oven dry specimen.
+        | *grams (g)*
+        | ``float``
+
+    moisture_content_mass_container
+        | Mass of container.
+        | *grams (g)*
+        | ``float``
+
+    moisture_content
+        | Moisture content.
+        | *percent (%)*
+        | ``float``
+
+        .. note::
+
+            :term:`moisture_content` mass measurements don't necessarily require using *grams (g)*
+            as the unit. However, **consistency** in the chosen units is essential.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,4 +72,10 @@ html_title = project
 html_theme_options = {
     "navbar_align": "left",
     "github_url": "https://github.com/fraserdominicdavid/geotech-pandas",
+    "show_nav_level": 4,
+}
+html_sidebars = {
+    "**": ["sidebar-nav-bs", "sidebar-ethical-ads"],
+    "changelog/index": [],
+    "column-reference/index": [],
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ geotech-pandas documentation
    
    User Guide <user-guide/index>
    API Reference <api-reference/index>
+   Column Reference <column-reference/index>
    Contribution <contribution/index>
    Changelog <changelog/index>
 
@@ -20,7 +21,7 @@ geotech-pandas documentation
 :mod:`geotech-pandas` is a `Pandas <https://pandas.pydata.org/>`__ extension for geotechnical
 calculations.
 
-.. grid:: 2
+.. grid:: 1 2 2 2
     :gutter: 4
     :padding: 2 2 0 0
     :class-container: sd-text-center
@@ -45,6 +46,16 @@ calculations.
       The reference guide contains a detailed description of the functions, modules, and objects
       included in geotech-pandas. The reference describes how the methods work and which parameters
       can be used. It assumes that you have an understanding of the key concepts.
+
+    .. grid-item-card:: Column Reference
+      :link: column-reference/index
+      :link-type: doc
+
+      :material-regular:`view_column;5em`
+      ^^^
+
+      The column reference contains general information about the columns used in geotech-pandas.
+      The reference provides the description, unit, and expected dtype for each column.
 
     .. grid-item-card:: Contribution
       :link: contribution/index

--- a/docs/user-guide/basics.rst
+++ b/docs/user-guide/basics.rst
@@ -19,7 +19,8 @@ Columns
 ^^^^^^^
 The minimum required columns for geotech-pandas are the ``point_id`` and ``bottom`` columns. The
 ``point_id`` represents the ID or the group where each layer belongs to. Whereas, the ``bottom``
-column represents the bottom depths of these layers. For more information, see :ref:`columns`.
+column represents the bottom depths of these layers. For more information, see
+:ref:`general-columns`.
 
 If you try to access :class:`~pandas.DataFrame.geotech` with the following
 :external:class:`~pandas.DataFrame`,

--- a/docs/user-guide/in-situ.spt.rst
+++ b/docs/user-guide/in-situ.spt.rst
@@ -5,7 +5,7 @@ In this guide, the basics of the :class:`~pandas.DataFrame.geotech.in_situ.spt` 
 are presented. The :class:`~pandas.DataFrame.geotech.in_situ.spt` subaccessor is a collection of
 methods related to standard penetration test (SPT) calculations for each sample of each point in the
 :external:class:`~pandas.DataFrame`. For information about the columns used by this
-subaccessor, see :ref:`columns_spt`.
+subaccessor, see :ref:`spt-columns`.
 
 First, we import the necessary libraries,
 

--- a/docs/user-guide/lab.index.rst
+++ b/docs/user-guide/lab.index.rst
@@ -6,7 +6,7 @@ are presented. The :class:`~pandas.DataFrame.geotech.lab.index` subaccessor is a
 methods related to index property laboratory tests for each sample of each point in the
 :external:class:`~pandas.DataFrame`. The index properties of soil are the properties which help to
 assess the engineering behavior of soil and determine the classification of soil accurately. For
-information about the columns used by this subaccessor, see :ref:`columns_lab_index`.
+information about the columns used by this subaccessor, see :ref:`soil-index-columns`.
 
 First, we import the necessary libraries,
 

--- a/docs/user-guide/layer.rst
+++ b/docs/user-guide/layer.rst
@@ -73,7 +73,7 @@ Then proceed with the following command to concatenate ``df`` with the results o
 As you can see, it results to the same :external:class:`~pandas.DataFrame` as before.
 
 It is recommended to use the :external:func:`~pandas.concat` method since geotech-pandas relies
-heavily in consistent column names. For more information, see :ref:`columns`.
+heavily in consistent column names. For more information, see :ref:`general-columns`.
 
 If you want the output to be much cleaner, you can always override the arrangement of columns like
 so,

--- a/src/geotech_pandas/in_situ/spt.py
+++ b/src/geotech_pandas/in_situ/spt.py
@@ -36,10 +36,15 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         Only full penetrations of 150 mm are returned, where partial penetrations are masked with
         `NA`.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`pen_1`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with seating penetration values.
+            :term:`seating_pen`
         """
         seating_pen = self._obj["pen_1"].convert_dtypes()
         seating_pen[seating_pen.ne(PEN_INC_MIN)] = pd.NA
@@ -48,10 +53,16 @@ class SPTDataFrameAccessor(GeotechPandasBase):
     def get_main_pen(self) -> pd.Series:
         """Return the total penetration in the second and third 150 mm increment for each sample.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`pen_2`
+            | :term:`pen_3`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with main penetration values.
+            :term:`main_pen`
         """
         return pd.Series(
             self._obj[["pen_2", "pen_3"]].sum(axis=1, min_count=1),
@@ -61,10 +72,17 @@ class SPTDataFrameAccessor(GeotechPandasBase):
     def get_total_pen(self) -> pd.Series:
         """Return the total penetration of each increment.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`pen_1`
+            | :term:`pen_2`
+            | :term:`pen_3`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with total penetration values.
+            :term:`total_pen`
         """
         return pd.Series(
             self._obj[["pen_1", "pen_2", "pen_3"]].sum(axis=1, min_count=1),
@@ -74,10 +92,16 @@ class SPTDataFrameAccessor(GeotechPandasBase):
     def get_seating_drive(self) -> pd.Series:
         """Return the number of blows in the first 150 mm increment for each sample.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`blows_1`
+            | :term:`pen_1`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with seating drive values.
+            :term:`seating_drive`
 
         Notes
         -----
@@ -94,10 +118,16 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         The sum is still returned regardless of the completeness of each increment. Due to this, the
         results may not correspond to the reported N-value.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`blows_2`
+            | :term:`blows_3`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with main drive values.
+            :term:`main_drive`
         """
         return pd.Series(
             self._obj[["blows_2", "blows_3"]].sum(axis=1, min_count=1),
@@ -109,10 +139,17 @@ class SPTDataFrameAccessor(GeotechPandasBase):
 
         The sum is still returned regardless of the completeness of each increment.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`blows_1`
+            | :term:`blows_2`
+            | :term:`blows_3`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with total drive values.
+            :term:`total_drive`
         """
         return pd.Series(
             self._obj[["blows_1", "blows_2", "blows_3"]].sum(axis=1, min_count=1),
@@ -174,10 +211,20 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         - partial penetration, which signifies that the sampler can no longer penetrate through the
           strata, is present in any of the increments.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`blows_1`
+            | :term:`blows_2`
+            | :term:`blows_3`
+            | :term:`pen_1`
+            | :term:`pen_2`
+            | :term:`pen_3`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series of booleans indicating whether or not each sample is refused.
+            :term:`is_refusal`
         """
         return pd.Series(
             self._any_blows_max_inc() | self._any_blows_max_total() | self._any_pen_partial(),
@@ -192,10 +239,20 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         - a total of 450 mm or more was penetrated by the sampler through sinking; and
         - each 150 mm increment has 0 blows recorded.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`blows_1`
+            | :term:`blows_2`
+            | :term:`blows_3`
+            | :term:`pen_1`
+            | :term:`pen_2`
+            | :term:`pen_3`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series of booleans indicating whether or not each sample is hammer weight.
+            :term:`is_hammer_weight`
         """
         return pd.Series(
             (self._obj[["blows_1", "blows_2", "blows_3"]].eq(0)).all(axis=1)
@@ -214,6 +271,16 @@ class SPTDataFrameAccessor(GeotechPandasBase):
             If `limit` is `True` while `refusal` is set to :external:attr:`~pandas.NA`,
             nothing will get limited.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`blows_1`
+            | :term:`blows_2`
+            | :term:`blows_3`
+            | :term:`pen_1`
+            | :term:`pen_2`
+            | :term:`pen_3`
+
         Parameters
         ----------
         refusal: int, default 50
@@ -224,7 +291,7 @@ class SPTDataFrameAccessor(GeotechPandasBase):
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with N-values.
+            :term:`n_value`
         """
         n_value = self.get_main_drive()
         n_value.loc[self.is_refusal()] = refusal
@@ -290,10 +357,20 @@ class SPTDataFrameAccessor(GeotechPandasBase):
          - ``(HW)`` for hammer weight samples
          - ``(R)`` for refusal samples
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`blows_1`
+            | :term:`blows_2`
+            | :term:`blows_3`
+            | :term:`pen_1`
+            | :term:`pen_2`
+            | :term:`pen_3`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with simple SPT descriptions.
+            :term:`spt_report`
         """
         return pd.Series(
             self._cat_blows().str.cat(self._format_n_value(), sep=" "),

--- a/src/geotech_pandas/lab/index.py
+++ b/src/geotech_pandas/lab/index.py
@@ -107,13 +107,17 @@ class IndexDataFrameAccessor(GeotechPandasBase):
     def get_moisture_content(self) -> pd.Series:
         r"""Return moisture content calculation according to ASTM D2216.
 
-        The moisture content is calculated from the `moisture_content_mass_moist`,
-        `moisture_content_mass_dry`, and `moisture_content_mass_container` columns of the dataframe.
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`moisture_content_mass_moist`
+            | :term:`moisture_content_mass_dry`
+            | :term:`moisture_content_mass_container`
 
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with moisture content values.
+            :term:`moisture_content`
 
         Notes
         -----

--- a/src/geotech_pandas/layer.py
+++ b/src/geotech_pandas/layer.py
@@ -18,6 +18,11 @@ class LayerDataFrameAccessor(GeotechPandasBase):
     def get_top(self, fill_value: float = 0.0) -> pd.Series:
         """Return shifted ``bottom`` depth values that can be used as ``top`` depth values.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`bottom`
+
         Parameters
         ----------
         fill_value: float, optional
@@ -26,7 +31,7 @@ class LayerDataFrameAccessor(GeotechPandasBase):
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with shifted ``bottom`` values.
+            :term:`top`
         """
         top = pd.Series(
             self._obj.geotech.point.groups["bottom"].shift(1, fill_value=fill_value), name="top"
@@ -37,10 +42,16 @@ class LayerDataFrameAccessor(GeotechPandasBase):
     def get_center(self) -> pd.Series:
         """Return ``center`` depth values from ``top`` and ``bottom`` depth values.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`top`
+            | :term:`bottom`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with ``center`` depth values.
+            :term:`center`
         """
         self._validate_columns(["top", "bottom"])
 
@@ -49,10 +60,16 @@ class LayerDataFrameAccessor(GeotechPandasBase):
     def get_thickness(self) -> pd.Series:
         """Return ``thickness`` values of ``top`` and ``bottom`` depth values.
 
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`top`
+            | :term:`bottom`
+
         Returns
         -------
         :external:class:`~pandas.Series`
-            Series with ``thickness`` values.
+            :term:`thickness`
         """
         self._validate_columns(["top", "bottom"])
 
@@ -74,6 +91,12 @@ class LayerDataFrameAccessor(GeotechPandasBase):
         This is particularly useful for cases where it is required or beneficial to split layers
         into two. For example, splitting a layer that is partly saturated and partly dry due to the
         groundwater level being found inside the layer.
+
+        .. admonition:: **Requires:**
+            :class: important
+
+            | :term:`top`
+            | :term:`bottom`
 
         Parameters
         ----------


### PR DESCRIPTION
## Description
Adds a separate page for the column reference.  It uses sphinx's glossary feature so the reference can be easily linked to relevant documentation. Additionally, a _Require_ admonition is included to every relevant API documentation that contains links to columns specified in the glossary.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.
