### PR TITLE
build(docs): ignore api reference build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ uv.lock
 
 # Sphinx
 docs/_build
+docs/api-reference/api


### PR DESCRIPTION
## Description
This PR adds the API reference build directory into `.gitignore` since these files are autogenerated during deployments.

## Tasks
<!-- Place `x` inside the `[ ]` (e.g. `[x]`) to mark the task as complete. -->
- [x] Ensure PR contains only one change.
- [x] Add unit tests with full coverage.
- [x] Update docs, if applicable.